### PR TITLE
Screen에서 불필요한 useEffect dependency(props) 제거

### DIFF
--- a/src/navigator/Screen.tsx
+++ b/src/navigator/Screen.tsx
@@ -2,7 +2,10 @@ import { action } from 'mobx'
 import React, { useEffect, useMemo } from 'react'
 
 import { generateScreenId } from '../utils'
-import { ScreenInstanceInfoProvider, ScreenInstanceOptionsProvider } from './contexts'
+import {
+  ScreenInstanceInfoProvider,
+  ScreenInstanceOptionsProvider,
+} from './contexts'
 import { ScreenComponentProps } from './ScreenComponentProps'
 import store, { NavbarOptions } from './store'
 
@@ -59,7 +62,7 @@ const Screen: React.FC<Props> = (props) => {
         )
       },
     })
-  }, [props])
+  }, [])
 
   return null
 }


### PR DESCRIPTION
In Screen component, the logic to set page component to store.screen has props as dependency.

This resulted the page component to mount every time the Screen component is rendered.

