### PR TITLE
fix(history-sync-plugin): fix getCurrentState() type error

### DIFF
--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -8,7 +8,7 @@ const SECOND = 1000;
 const MINUTE = 60 * SECOND;
 
 function getCurrentState() {
-  return window.history.state;
+  return window.history.state ?? {};
 }
 
 interface State {


### PR DESCRIPTION
https://github.com/daangn/stackflow/issues/182

`parseState(getCurrentState())`부분 object deeps 안맞는 버그 수정