### PR TITLE
fix(react): Support reserved words(ref, key) in `activityParams`

### DIFF
--- a/demo/src/activities/Article.tsx
+++ b/demo/src/activities/Article.tsx
@@ -1,4 +1,4 @@
-import { useActivityParams } from "@stackflow/react";
+import { ActivityComponentType, useActivityParams } from "@stackflow/react";
 import React from "react";
 import { LazyLoadImage } from "react-lazy-load-image-component";
 
@@ -64,7 +64,7 @@ export interface ArticleParams {
   articleId: string;
   title: string;
 }
-const Article: React.FC<ArticleParams> = () => {
+const Article: ActivityComponentType<ArticleParams> = () => {
   const { articleId, title } = useActivityParams<{
     articleId: string;
     title: string;

--- a/demo/src/activities/Main.tsx
+++ b/demo/src/activities/Main.tsx
@@ -1,3 +1,4 @@
+import { ActivityComponentType } from "@stackflow/react";
 import React from "react";
 
 import IconBell from "../assets/IconBell";
@@ -82,7 +83,7 @@ const cards = [
   },
 ];
 
-const Main: React.FC = () => {
+const Main: ActivityComponentType = () => {
   const appBarLeft = () => (
     <div className={css.appBarLeft}>
       Woolston

--- a/integrations/react/src/MainRenderer.tsx
+++ b/integrations/react/src/MainRenderer.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect } from "react";
 
+import { BaseActivities } from "./BaseActivities";
 import { useCoreState } from "./core";
 import PluginRenderer from "./PluginRenderer";
 import { usePlugins } from "./plugins";
 import { WithRequired } from "./utils";
 
 interface MainRendererProps {
-  activities: { [key: string]: React.ComponentType };
+  activities: BaseActivities;
 }
 const MainRenderer: React.FC<MainRendererProps> = ({ activities }) => {
   const coreState = useCoreState();

--- a/integrations/react/src/PluginRenderer.tsx
+++ b/integrations/react/src/PluginRenderer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { ActivityProvider } from "./activity";
+import { BaseActivities } from "./BaseActivities";
 import { useCoreState } from "./core";
 import { usePlugins } from "./plugins";
 import { StackProvider } from "./stack";
@@ -8,7 +9,7 @@ import { StackflowReactPlugin } from "./StackflowReactPlugin";
 import { WithRequired } from "./utils";
 
 interface PluginRendererProps {
-  activities: { [key: string]: React.ComponentType };
+  activities: BaseActivities;
   plugin: WithRequired<ReturnType<StackflowReactPlugin>, "render">;
 }
 const PluginRenderer: React.FC<PluginRendererProps> = ({
@@ -34,7 +35,7 @@ const PluginRenderer: React.FC<PluginRendererProps> = ({
             render(overrideActivity) {
               const ActivityComponent = activities[activity.name];
 
-              let output = <ActivityComponent {...activity.params} />;
+              let output = <ActivityComponent params={activity.params} />;
 
               plugins.forEach((p) => {
                 output =

--- a/integrations/react/src/activity/ActivityComponentType.tsx
+++ b/integrations/react/src/activity/ActivityComponentType.tsx
@@ -2,4 +2,4 @@ import { ActivityParams } from "@stackflow/core";
 import React from "react";
 
 export type ActivityComponentType<T extends ActivityParams<T> = {}> =
-  React.ComponentType<T>;
+  React.ComponentType<{ params: T }>;


### PR DESCRIPTION
- `params` 필드로 액티비티 컴포넌트의 props를 한번 감쌉니다.

BREAKING CHANGES: 기존에 Props 인터페이스를 통해 Activity Params를 받아오던 부분에 파괴적 변환이 발생합니다.

CLOSE: #206 