### PR TITLE
feat(compat-await-push): compat library for await push interface

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -37,6 +37,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         "reference": "workspace:extensions/basic-ui"\
       },\
       {\
+        "name": "@stackflow/compat-await-push",\
+        "reference": "workspace:extensions/compat-await-push"\
+      },\
+      {\
         "name": "@stackflow/link",\
         "reference": "workspace:extensions/link"\
       },\
@@ -65,6 +69,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
     "ignorePatternData": "(^(?:\\\\.yarn\\\\/sdks(?:\\\\/(?!\\\\.{1,2}(?:\\\\/|$))(?:(?:(?!(?:^|\\\\/)\\\\.{1,2}(?:\\\\/|$)).)*?)|$))$)",\
     "fallbackExclusionList": [\
       ["@stackflow/basic-ui", ["virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/basic-ui", "workspace:extensions/basic-ui"]],\
+      ["@stackflow/compat-await-push", ["virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/compat-await-push", "workspace:extensions/compat-await-push"]],\
       ["@stackflow/core", ["workspace:core"]],\
       ["@stackflow/demo", ["workspace:demo"]],\
       ["@stackflow/docs", ["workspace:docs"]],\
@@ -2976,6 +2981,48 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "SOFT"\
         }]\
       ]],\
+      ["@stackflow/compat-await-push", [\
+        ["virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/compat-await-push", {\
+          "packageLocation": "./.yarn/__virtual__/@stackflow-compat-await-push-virtual-fdeadfebbb/1/extensions/compat-await-push/",\
+          "packageDependencies": [\
+            ["@stackflow/compat-await-push", "virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/compat-await-push"],\
+            ["@stackflow/core", "workspace:core"],\
+            ["@stackflow/esbuild-config", "workspace:packages/esbuild-config"],\
+            ["@stackflow/react", "virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:integrations/react"],\
+            ["@types/react", "npm:18.0.15"],\
+            ["@types/stackflow__core", null],\
+            ["@types/stackflow__react", null],\
+            ["esbuild", "npm:0.14.51"],\
+            ["react", "npm:18.2.0"],\
+            ["rimraf", "npm:3.0.2"],\
+            ["typescript", "patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=f456af"]\
+          ],\
+          "packagePeers": [\
+            "@stackflow/core",\
+            "@stackflow/react",\
+            "@types/react",\
+            "@types/stackflow__core",\
+            "@types/stackflow__react",\
+            "react"\
+          ],\
+          "linkType": "SOFT"\
+        }],\
+        ["workspace:extensions/compat-await-push", {\
+          "packageLocation": "./extensions/compat-await-push/",\
+          "packageDependencies": [\
+            ["@stackflow/compat-await-push", "workspace:extensions/compat-await-push"],\
+            ["@stackflow/core", "workspace:core"],\
+            ["@stackflow/esbuild-config", "workspace:packages/esbuild-config"],\
+            ["@stackflow/react", "virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:integrations/react"],\
+            ["@types/react", "npm:18.0.15"],\
+            ["esbuild", "npm:0.14.51"],\
+            ["react", "npm:18.2.0"],\
+            ["rimraf", "npm:3.0.2"],\
+            ["typescript", "patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=f456af"]\
+          ],\
+          "linkType": "SOFT"\
+        }]\
+      ]],\
       ["@stackflow/core", [\
         ["workspace:core", {\
           "packageLocation": "./core/",\
@@ -3004,6 +3051,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@seed-design/design-token", "npm:1.0.0-alpha.5"],\
             ["@seed-design/stylesheet", "npm:1.0.0-alpha.3"],\
             ["@stackflow/basic-ui", "virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/basic-ui"],\
+            ["@stackflow/compat-await-push", "virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/compat-await-push"],\
             ["@stackflow/core", "workspace:core"],\
             ["@stackflow/esbuild-config", "workspace:packages/esbuild-config"],\
             ["@stackflow/link", "virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/link"],\

--- a/demo/package.json
+++ b/demo/package.json
@@ -30,6 +30,7 @@
     "@seed-design/design-token": "^1.0.0-alpha.0",
     "@seed-design/stylesheet": "^1.0.0-alpha.0",
     "@stackflow/basic-ui": "^0.10.0",
+    "@stackflow/compat-await-push": "^0.10.0",
     "@stackflow/core": "^0.10.0",
     "@stackflow/link": "^0.10.0",
     "@stackflow/plugin-history-sync": "^0.10.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -30,7 +30,7 @@
     "@seed-design/design-token": "^1.0.0-alpha.0",
     "@seed-design/stylesheet": "^1.0.0-alpha.0",
     "@stackflow/basic-ui": "^0.10.0",
-    "@stackflow/compat-await-push": "^0.10.0",
+    "@stackflow/compat-await-push": "^0.9.0",
     "@stackflow/core": "^0.10.0",
     "@stackflow/link": "^0.10.0",
     "@stackflow/plugin-history-sync": "^0.10.0",

--- a/extensions/compat-await-push/README.md
+++ b/extensions/compat-await-push/README.md
@@ -1,0 +1,40 @@
+# @stackflow/compat-await-push
+
+## Usage
+
+```typescript
+import { receive } from "@stackflow/compat-await-push";
+
+const MyActivity = () => {
+  const { push } = useFlow();
+
+  const onClick = async () => {
+    const data = await receive(
+      push("NextActivity", {
+        // ...
+      }),
+    );
+
+    console.log(data);
+  };
+};
+```
+
+```typescript
+import { send } from "@stackflow/compat-await-push";
+
+const NextActivity = () => {
+  const { id } = useActivity();
+  const { pop } = useFlow();
+
+  const onClick = async () => {
+    pop();
+    send({
+      activityId: id,
+      data: {
+        hello: "world",
+      },
+    });
+  };
+};
+```

--- a/extensions/compat-await-push/esbuild.config.js
+++ b/extensions/compat-await-push/esbuild.config.js
@@ -1,0 +1,29 @@
+const { build } = require("esbuild");
+const config = require("@stackflow/esbuild-config");
+const pkg = require("./package.json");
+
+const watch = process.argv.includes("--watch");
+const external = Object.keys({
+  ...pkg.dependencies,
+  ...pkg.peerDependencies,
+});
+
+Promise.all([
+  build({
+    ...config({}),
+    format: "cjs",
+    external,
+    watch,
+    minify: !watch,
+  }),
+  build({
+    ...config({}),
+    format: "esm",
+    outExtension: {
+      ".js": ".mjs",
+    },
+    external,
+    watch,
+    minify: !watch,
+  }),
+]).catch(() => process.exit(1));

--- a/extensions/compat-await-push/package.json
+++ b/extensions/compat-await-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackflow/compat-await-push",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "exports": {
     ".": {
@@ -24,9 +24,9 @@
     "dev": "yarn build:js --watch && yarn build:dts --watch"
   },
   "devDependencies": {
-    "@stackflow/core": "^0.9.1",
-    "@stackflow/esbuild-config": "^0.9.0",
-    "@stackflow/react": "^0.9.1",
+    "@stackflow/core": "^0.10.0",
+    "@stackflow/esbuild-config": "^0.10.0",
+    "@stackflow/react": "^0.10.0",
     "@types/react": "^18.0.10",
     "esbuild": "^0.14.51",
     "react": "^18.1.0",

--- a/extensions/compat-await-push/package.json
+++ b/extensions/compat-await-push/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@stackflow/compat-await-push",
+  "version": "0.9.0",
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "yarn build:js && yarn build:dts",
+    "build:dts": "tsc --emitDeclarationOnly",
+    "build:js": "node ./esbuild.config.js",
+    "clean": "rimraf dist",
+    "dev": "yarn build:js --watch && yarn build:dts --watch"
+  },
+  "devDependencies": {
+    "@stackflow/core": "^0.9.1",
+    "@stackflow/esbuild-config": "^0.9.0",
+    "@stackflow/react": "^0.9.1",
+    "@types/react": "^18.0.10",
+    "esbuild": "^0.14.51",
+    "react": "^18.1.0",
+    "rimraf": "^3.0.2",
+    "typescript": "^4.7.4"
+  },
+  "peerDependencies": {
+    "@stackflow/core": "0",
+    "@stackflow/react": "0",
+    "@types/react": ">=16.8.0",
+    "react": ">=16.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "ultra": {
+    "concurrent": [
+      "dev",
+      "build"
+    ]
+  }
+}

--- a/extensions/compat-await-push/package.json
+++ b/extensions/compat-await-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackflow/compat-await-push",
-  "version": "0.10.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": {
     ".": {

--- a/extensions/compat-await-push/src/index.ts
+++ b/extensions/compat-await-push/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./receive";
+export * from "./send";

--- a/extensions/compat-await-push/src/receive.ts
+++ b/extensions/compat-await-push/src/receive.ts
@@ -1,0 +1,7 @@
+import { resolveMap } from "./resolveMap";
+
+export function receive<T = unknown>({ activityId }: { activityId: string }) {
+  return new Promise<T>((resolve: any) => {
+    resolveMap[activityId] = resolve;
+  });
+}

--- a/extensions/compat-await-push/src/resolveMap.ts
+++ b/extensions/compat-await-push/src/resolveMap.ts
@@ -1,0 +1,3 @@
+export const resolveMap: {
+  [key: string]: (value: unknown) => void;
+} = {};

--- a/extensions/compat-await-push/src/send.ts
+++ b/extensions/compat-await-push/src/send.ts
@@ -1,0 +1,11 @@
+import { resolveMap } from "./resolveMap";
+
+export function send({
+  activityId,
+  data,
+}: {
+  activityId: string;
+  data: unknown;
+}) {
+  resolveMap[activityId]?.(data);
+}

--- a/extensions/compat-await-push/tsconfig.json
+++ b/extensions/compat-await-push/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["./dist"]
+}

--- a/integrations/react/src/useActions.ts
+++ b/integrations/react/src/useActions.ts
@@ -72,16 +72,14 @@ export function useActions<
       push(activityName, params, options) {
         const activityId = makeActivityId();
 
-        if (!pending) {
-          startTransition(() => {
-            coreActions.push({
-              activityId,
-              activityName,
-              params,
-              skipEnterActiveState: parseActionOptions(options).skipActiveState,
-            });
+        startTransition(() => {
+          coreActions.push({
+            activityId,
+            activityName,
+            params,
+            skipEnterActiveState: parseActionOptions(options).skipActiveState,
           });
-        }
+        });
 
         return {
           activityId,
@@ -90,29 +88,25 @@ export function useActions<
       replace(activityName, params, options) {
         const activityId = makeActivityId();
 
-        if (!pending) {
-          startTransition(() => {
-            coreActions.replace({
-              activityId: makeActivityId(),
-              activityName,
-              params,
-              skipEnterActiveState: parseActionOptions(options).skipActiveState,
-            });
+        startTransition(() => {
+          coreActions.replace({
+            activityId: makeActivityId(),
+            activityName,
+            params,
+            skipEnterActiveState: parseActionOptions(options).skipActiveState,
           });
-        }
+        });
 
         return {
           activityId,
         };
       },
       pop(options) {
-        if (!pending) {
-          startTransition(() => {
-            coreActions.pop({
-              skipExitActiveState: parseActionOptions(options).skipActiveState,
-            });
+        startTransition(() => {
+          coreActions.pop({
+            skipExitActiveState: parseActionOptions(options).skipActiveState,
           });
-        }
+        });
       },
     }),
     [

--- a/integrations/react/src/useActions.ts
+++ b/integrations/react/src/useActions.ts
@@ -34,7 +34,9 @@ export type UseActionsOutputType<T extends BaseActivities> = {
     options?: {
       animate?: boolean;
     },
-  ) => void;
+  ) => {
+    activityId: string;
+  };
 
   /**
    * Push new activity in the top and remove current top activity when new activity is activated
@@ -45,7 +47,9 @@ export type UseActionsOutputType<T extends BaseActivities> = {
     options?: {
       animate?: boolean;
     },
-  ) => void;
+  ) => {
+    activityId: string;
+  };
 
   /**
    * Remove top activity
@@ -66,40 +70,49 @@ export function useActions<
     () => ({
       pending,
       push(activityName, params, options) {
-        if (pending) {
-          return;
-        }
-        startTransition(() => {
-          coreActions.push({
-            activityId: makeActivityId(),
-            activityName,
-            params,
-            skipEnterActiveState: parseActionOptions(options).skipActiveState,
+        const activityId = makeActivityId();
+
+        if (!pending) {
+          startTransition(() => {
+            coreActions.push({
+              activityId,
+              activityName,
+              params,
+              skipEnterActiveState: parseActionOptions(options).skipActiveState,
+            });
           });
-        });
+        }
+
+        return {
+          activityId,
+        };
       },
       replace(activityName, params, options) {
-        if (pending) {
-          return;
-        }
-        startTransition(() => {
-          coreActions.replace({
-            activityId: makeActivityId(),
-            activityName,
-            params,
-            skipEnterActiveState: parseActionOptions(options).skipActiveState,
+        const activityId = makeActivityId();
+
+        if (!pending) {
+          startTransition(() => {
+            coreActions.replace({
+              activityId: makeActivityId(),
+              activityName,
+              params,
+              skipEnterActiveState: parseActionOptions(options).skipActiveState,
+            });
           });
-        });
+        }
+
+        return {
+          activityId,
+        };
       },
       pop(options) {
-        if (pending) {
-          return;
-        }
-        startTransition(() => {
-          coreActions.pop({
-            skipExitActiveState: parseActionOptions(options).skipActiveState,
+        if (!pending) {
+          startTransition(() => {
+            coreActions.pop({
+              skipExitActiveState: parseActionOptions(options).skipActiveState,
+            });
           });
-        });
+        }
       },
     }),
     [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,7 +2161,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@stackflow/compat-await-push@^0.10.0, @stackflow/compat-await-push@workspace:extensions/compat-await-push":
+"@stackflow/compat-await-push@^0.9.0, @stackflow/compat-await-push@workspace:extensions/compat-await-push":
   version: 0.0.0-use.local
   resolution: "@stackflow/compat-await-push@workspace:extensions/compat-await-push"
   dependencies:
@@ -2206,7 +2206,7 @@ __metadata:
     "@seed-design/design-token": ^1.0.0-alpha.0
     "@seed-design/stylesheet": ^1.0.0-alpha.0
     "@stackflow/basic-ui": ^0.10.0
-    "@stackflow/compat-await-push": ^0.10.0
+    "@stackflow/compat-await-push": ^0.9.0
     "@stackflow/core": ^0.10.0
     "@stackflow/esbuild-config": ^0.10.0
     "@stackflow/link": ^0.10.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,6 +2161,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@stackflow/compat-await-push@^0.10.0, @stackflow/compat-await-push@workspace:extensions/compat-await-push":
+  version: 0.0.0-use.local
+  resolution: "@stackflow/compat-await-push@workspace:extensions/compat-await-push"
+  dependencies:
+    "@stackflow/core": ^0.10.0
+    "@stackflow/esbuild-config": ^0.10.0
+    "@stackflow/react": ^0.10.0
+    "@types/react": ^18.0.10
+    esbuild: ^0.14.51
+    react: ^18.1.0
+    rimraf: ^3.0.2
+    typescript: ^4.7.4
+  peerDependencies:
+    "@stackflow/core": 0
+    "@stackflow/react": 0
+    "@types/react": ">=16.8.0"
+    react: ">=16.8.0"
+  languageName: unknown
+  linkType: soft
+
 "@stackflow/core@^0.10.0, @stackflow/core@workspace:core":
   version: 0.0.0-use.local
   resolution: "@stackflow/core@workspace:core"
@@ -2186,6 +2206,7 @@ __metadata:
     "@seed-design/design-token": ^1.0.0-alpha.0
     "@seed-design/stylesheet": ^1.0.0-alpha.0
     "@stackflow/basic-ui": ^0.10.0
+    "@stackflow/compat-await-push": ^0.10.0
     "@stackflow/core": ^0.10.0
     "@stackflow/esbuild-config": ^0.10.0
     "@stackflow/link": ^0.10.0


### PR DESCRIPTION
## 내용
기존에 Karrotframe에 존재하던 `await push()`, `pop().send()` 인터페이스를 모방한 Compat 라이브러리를 제공합니다.

```typescript
import { receive } from "@stackflow/compat-await-push";

const MyActivity = () => {
  const { push } = useFlow();

  const onClick = async () => {
    const data = await receive(
      push("NextActivity", {
        // ...
      }),
    );
    console.log(data);
  };
};
```

```typescript
import { send } from "@stackflow/compat-await-push";

const NextActivity = () => {
  const { id } = useActivity();
  const { pop } = useFlow();

  const onClick = async () => {
    pop();
    send({
      activityId: id,
      data: {
        hello: "world",
      },
    });
  };
};
```

## 변경사항
`push()`, `replace()` 함수에서 새로 생성된 `activityId`를 반환합니다 (기존: `void`)