### PR TITLE
feat(basic-ui): backButton, closeButton

### DIFF
--- a/extensions/basic-ui/src/AppBar.tsx
+++ b/extensions/basic-ui/src/AppBar.tsx
@@ -21,7 +21,7 @@ interface AppBarProps {
   backButton?:
     | {
         renderIcon?: () => React.ReactNode;
-        onClick?: () => void;
+        onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
       }
     | {
         render?: () => React.ReactNode;
@@ -29,7 +29,7 @@ interface AppBarProps {
   closeButton?:
     | {
         renderIcon?: () => React.ReactNode;
-        onClick?: () => void;
+        onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
       }
     | {
         render?: () => React.ReactNode;
@@ -80,8 +80,14 @@ const AppBar: React.FC<AppBarProps> = ({
     enable: theme === "cupertino",
   });
 
-  const onBack = () => {
-    actions.pop();
+  const onBack = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (backButton && "onClick" in backButton && backButton.onClick) {
+      backButton.onClick(e);
+    }
+
+    if (!e.defaultPrevented) {
+      actions.pop();
+    }
   };
 
   const renderBackButton = () => {
@@ -102,15 +108,7 @@ const AppBar: React.FC<AppBarProps> = ({
     }
 
     return (
-      <button
-        type="button"
-        className={css.backButton}
-        onClick={
-          "onClick" in backButton && backButton.onClick
-            ? backButton.onClick
-            : onBack
-        }
-      >
+      <button type="button" className={css.backButton} onClick={onBack}>
         {"renderIcon" in backButton && backButton.renderIcon ? (
           backButton.renderIcon()
         ) : (

--- a/extensions/basic-ui/src/AppBar.tsx
+++ b/extensions/basic-ui/src/AppBar.tsx
@@ -20,13 +20,13 @@ interface AppBarProps {
   backButton?:
     | {
         customIcon?: () => React.ReactNode;
-        onBackButtonClick?: () => void;
+        onClick?: () => void;
       }
     | (() => React.ReactNode);
   closeButton?:
     | {
         customIcon?: () => React.ReactNode;
-        onCloseButtonClick?: () => void;
+        onClick?: () => void;
       }
     | (() => React.ReactNode);
   closeButtonLocation?: "left" | "right";
@@ -91,7 +91,7 @@ const AppBar: React.FC<AppBarProps> = ({
       <button
         type="button"
         className={css.backButton}
-        onClick={backButton?.onBackButtonClick ?? onBack}
+        onClick={backButton?.onClick ?? onBack}
       >
         {backButton?.customIcon ? backButton.customIcon() : <IconBack />}
       </button>
@@ -110,7 +110,7 @@ const AppBar: React.FC<AppBarProps> = ({
       <button
         type="button"
         className={css.closeButton}
-        onClick={closeButton.onCloseButtonClick}
+        onClick={closeButton.onClick}
       >
         {closeButton.customIcon ? closeButton.customIcon() : <IconClose />}
       </button>

--- a/extensions/basic-ui/src/AppBar.tsx
+++ b/extensions/basic-ui/src/AppBar.tsx
@@ -7,6 +7,7 @@ import * as appScreenCss from "./AppScreen.css";
 import { IconBack, IconClose } from "./assets";
 import {
   compactMap,
+  noop,
   useActiveActivities,
   useMaxWidth,
   useTopActiveActivity,
@@ -19,16 +20,20 @@ interface AppBarProps {
   appendRight?: () => React.ReactNode;
   backButton?:
     | {
-        customIcon?: () => React.ReactNode;
+        renderIcon?: () => React.ReactNode;
         onClick?: () => void;
       }
-    | (() => React.ReactNode);
+    | {
+        render?: () => React.ReactNode;
+      };
   closeButton?:
     | {
-        customIcon?: () => React.ReactNode;
+        renderIcon?: () => React.ReactNode;
         onClick?: () => void;
       }
-    | (() => React.ReactNode);
+    | {
+        render?: () => React.ReactNode;
+      };
   closeButtonLocation?: "left" | "right";
   border?: boolean;
   iconColor?: string;
@@ -83,17 +88,34 @@ const AppBar: React.FC<AppBarProps> = ({
     if (isCloseButtonVisible) {
       return null;
     }
-    if (typeof backButton === "function") {
-      return backButton();
+
+    if (!backButton) {
+      return (
+        <button type="button" className={css.backButton} onClick={onBack}>
+          <IconBack />
+        </button>
+      );
+    }
+
+    if ("render" in backButton && backButton.render) {
+      return backButton.render?.();
     }
 
     return (
       <button
         type="button"
         className={css.backButton}
-        onClick={backButton?.onClick ?? onBack}
+        onClick={
+          "onClick" in backButton && backButton.onClick
+            ? backButton.onClick
+            : onBack
+        }
       >
-        {backButton?.customIcon ? backButton.customIcon() : <IconBack />}
+        {"renderIcon" in backButton && backButton.renderIcon ? (
+          backButton.renderIcon()
+        ) : (
+          <IconBack />
+        )}
       </button>
     );
   };
@@ -102,17 +124,21 @@ const AppBar: React.FC<AppBarProps> = ({
     if (!closeButton || !isCloseButtonVisible) {
       return null;
     }
-    if (typeof closeButton === "function") {
-      return closeButton();
+    if ("render" in closeButton && closeButton.render) {
+      return closeButton.render();
     }
 
     return (
       <button
         type="button"
         className={css.closeButton}
-        onClick={closeButton.onClick}
+        onClick={"onClick" in closeButton ? closeButton.onClick : noop}
       >
-        {closeButton.customIcon ? closeButton.customIcon() : <IconClose />}
+        {"renderIcon" in closeButton && closeButton.renderIcon ? (
+          closeButton.renderIcon()
+        ) : (
+          <IconClose />
+        )}
       </button>
     );
   };

--- a/extensions/basic-ui/src/AppBar.tsx
+++ b/extensions/basic-ui/src/AppBar.tsx
@@ -17,10 +17,19 @@ interface AppBarProps {
   title?: React.ReactNode;
   appendLeft?: () => React.ReactNode;
   appendRight?: () => React.ReactNode;
+  backButton?:
+    | {
+        customIcon?: () => React.ReactNode;
+        onBackButtonClick?: () => void;
+      }
+    | (() => React.ReactNode);
+  closeButton?:
+    | {
+        customIcon?: () => React.ReactNode;
+        onCloseButtonClick?: () => void;
+      }
+    | (() => React.ReactNode);
   closeButtonLocation?: "left" | "right";
-  customBackButton?: () => React.ReactNode;
-  customCloseButton?: () => React.ReactNode;
-  onClose?: () => void;
   border?: boolean;
   iconColor?: string;
   textColor?: string;
@@ -32,10 +41,9 @@ const AppBar: React.FC<AppBarProps> = ({
   title,
   appendLeft,
   appendRight,
+  backButton,
+  closeButton,
   closeButtonLocation = "left",
-  customBackButton,
-  customCloseButton,
-  onClose,
   border = true,
   iconColor,
   textColor,
@@ -71,17 +79,43 @@ const AppBar: React.FC<AppBarProps> = ({
     actions.pop();
   };
 
-  const backButton = !isCloseButtonVisible && (
-    <button type="button" className={css.backButton} onClick={onBack}>
-      {customBackButton ? customBackButton() : <IconBack />}
-    </button>
-  );
+  const renderBackButton = () => {
+    if (isCloseButtonVisible) {
+      return null;
+    }
+    if (typeof backButton === "function") {
+      return backButton();
+    }
 
-  const closeButton = onClose && isCloseButtonVisible && (
-    <button type="button" className={css.closeButton} onClick={onClose}>
-      {customCloseButton ? customCloseButton() : <IconClose />}
-    </button>
-  );
+    return (
+      <button
+        type="button"
+        className={css.backButton}
+        onClick={backButton?.onBackButtonClick ?? onBack}
+      >
+        {backButton?.customIcon ? backButton.customIcon() : <IconBack />}
+      </button>
+    );
+  };
+
+  const renderCloseButton = () => {
+    if (!closeButton || !isCloseButtonVisible) {
+      return null;
+    }
+    if (typeof closeButton === "function") {
+      return closeButton();
+    }
+
+    return (
+      <button
+        type="button"
+        className={css.closeButton}
+        onClick={closeButton.onCloseButtonClick}
+      >
+        {closeButton.customIcon ? closeButton.customIcon() : <IconClose />}
+      </button>
+    );
+  };
 
   const hasLeft = !!(
     (closeButtonLocation === "left" && closeButton) ||
@@ -107,8 +141,8 @@ const AppBar: React.FC<AppBarProps> = ({
       )}
     >
       <div className={css.left}>
-        {closeButtonLocation === "left" && closeButton}
-        {backButton}
+        {closeButtonLocation === "left" && renderCloseButton()}
+        {renderBackButton()}
         {appendLeft?.()}
       </div>
       <div ref={centerRef} className={css.center}>
@@ -126,7 +160,7 @@ const AppBar: React.FC<AppBarProps> = ({
       </div>
       <div className={css.right}>
         {appendRight?.()}
-        {closeButtonLocation === "right" && closeButton}
+        {closeButtonLocation === "right" && renderCloseButton()}
       </div>
     </div>
   );


### PR DESCRIPTION
## Breaking Changes
기존에 `customBackButton`, `customCloseButton`은 어떤걸 커스텀하는건지 모호했어요. 이 부분을 해결해요.

### ex1: 닫기 버튼을 뒤로가기 아이콘으로 바꾸기
```tsx
// as-is
<AppScreen
  customCloseButton={() => <IcBack />}
/>

// to-be
<AppScreen
  closeButton={{
    renderIcon: () => <IcBack />
  }}
/>
```

### ex2: 닫기 버튼에 행동 교체하기
```tsx
// as-is
<AppScreen
  onClose={() => { ... })
/>

// to-be
<AppScreen
  closeButton={{
    onClick() { ... }
  }}
/>
```

### ex3: 아얘 싹 다 바꾸기
```tsx
// as-is
// 불가능

// to-be
<AppScreen
  closeButton={{
    render() { ... },
  }}
/>
```