### PR TITLE
refactor(react): hide `stackRef` interface with actions

### DIFF
--- a/demo/src/stackflow.ts
+++ b/demo/src/stackflow.ts
@@ -31,6 +31,7 @@ export const { Stack, useFlow } = stackflow({
     }),
     basicUIPlugin({
       theme,
+      backgroundColor: vars.$semantic.color.paperDefault,
       appBar: {
         textColor: vars.$scale.color.gray900,
         iconColor: vars.$scale.color.gray900,

--- a/integrations/react/src/StackRefManager.tsx
+++ b/integrations/react/src/StackRefManager.tsx
@@ -1,14 +1,14 @@
+import type { StackflowPluginActions } from "@stackflow/core";
 import React from "react";
 
 import type { BaseActivities } from "./BaseActivities";
-import type { CoreActionsContextValue } from "./core";
 import { useCoreActions } from "./core";
 import type { UseActionsOutputType } from "./useActions";
 import { useActions } from "./useActions";
 
 export type StackRefCurrentType<T extends BaseActivities> = {
-  actions: Pick<UseActionsOutputType<T>, "push" | "pop" | "replace"> &
-    CoreActionsContextValue;
+  actions: Pick<StackflowPluginActions, "dispatchEvent" | "getStack"> &
+    Pick<UseActionsOutputType<T>, "push" | "pop" | "replace">;
 };
 
 const StackRefManager = React.forwardRef<

--- a/integrations/react/src/stackflow.tsx
+++ b/integrations/react/src/stackflow.tsx
@@ -92,29 +92,29 @@ export function stackflow<T extends BaseActivities>(
   const stackRef: StackRefType<T> = {
     current: null,
   };
-  const stackRefNotFoundErrorMessage =
-    "<Stack /> component has not been mounted." +
-    " Make sure you include it within your React tree." +
-    " Or, make sure you call the function after it is rendered.";
+  const stackRefNotFoundErrorMessage = (funcName: string) =>
+    "`<Stack />` component has not been mounted." +
+    " Make sure you include `<Stack />` within your React tree." +
+    ` Or, make sure you call \`${funcName}()\` after it is rendered.`;
 
   const actions: StackflowOutput<T>["actions"] = {
     dispatchEvent(name, parameters) {
       if (!stackRef.current) {
-        throw new Error(stackRefNotFoundErrorMessage);
+        throw new Error(stackRefNotFoundErrorMessage("dispatchEvent"));
       }
 
-      return stackRef.current?.actions.dispatchEvent(name, parameters);
+      return stackRef.current.actions.dispatchEvent(name, parameters);
     },
     getStack() {
       if (!stackRef.current) {
-        throw new Error(stackRefNotFoundErrorMessage);
+        throw new Error(stackRefNotFoundErrorMessage("getStack"));
       }
 
       return stackRef.current.actions.getStack();
     },
     push(activityName, activityParams, options) {
       if (!stackRef.current) {
-        throw new Error(stackRefNotFoundErrorMessage);
+        throw new Error(stackRefNotFoundErrorMessage("push"));
       }
 
       return stackRef.current.actions.push(
@@ -125,14 +125,14 @@ export function stackflow<T extends BaseActivities>(
     },
     pop(options) {
       if (!stackRef.current) {
-        throw new Error(stackRefNotFoundErrorMessage);
+        throw new Error(stackRefNotFoundErrorMessage("pop"));
       }
 
       return stackRef.current.actions.pop(options);
     },
     replace(activityName, activityParams, options) {
       if (!stackRef.current) {
-        throw new Error(stackRefNotFoundErrorMessage);
+        throw new Error(stackRefNotFoundErrorMessage("replace"));
       }
 
       return stackRef.current.actions.replace(

--- a/integrations/react/src/stackflow.tsx
+++ b/integrations/react/src/stackflow.tsx
@@ -1,3 +1,4 @@
+import type { StackflowPluginActions } from "@stackflow/core";
 import React, { useMemo } from "react";
 
 import type { BaseActivities } from "./BaseActivities";
@@ -59,9 +60,10 @@ export type StackflowOutput<T extends BaseActivities> = {
   useFlow: () => UseActionsOutputType<T>;
 
   /**
-   * Created imperative handles
+   * Created action triggers
    */
-  createStackRef: () => StackRefType<T>;
+  actions: Pick<StackflowPluginActions, "dispatchEvent" | "getStack"> &
+    Pick<UseActionsOutputType<T>, "push" | "pop" | "replace">;
 };
 
 /**
@@ -89,6 +91,56 @@ export function stackflow<T extends BaseActivities>(
 
   const stackRef: StackRefType<T> = {
     current: null,
+  };
+  const stackRefNotFoundErrorMessage =
+    "<Stack /> component has not been mounted." +
+    " Make sure you include it within your React tree." +
+    " Or, make sure you call the function after it is rendered.";
+
+  const actions: StackflowOutput<T>["actions"] = {
+    dispatchEvent(name, parameters) {
+      if (!stackRef.current) {
+        throw new Error(stackRefNotFoundErrorMessage);
+      }
+
+      return stackRef.current?.actions.dispatchEvent(name, parameters);
+    },
+    getStack() {
+      if (!stackRef.current) {
+        throw new Error(stackRefNotFoundErrorMessage);
+      }
+
+      return stackRef.current.actions.getStack();
+    },
+    push(activityName, activityParams, options) {
+      if (!stackRef.current) {
+        throw new Error(stackRefNotFoundErrorMessage);
+      }
+
+      return stackRef.current.actions.push(
+        activityName,
+        activityParams,
+        options,
+      );
+    },
+    pop(options) {
+      if (!stackRef.current) {
+        throw new Error(stackRefNotFoundErrorMessage);
+      }
+
+      return stackRef.current.actions.pop(options);
+    },
+    replace(activityName, activityParams, options) {
+      if (!stackRef.current) {
+        throw new Error(stackRefNotFoundErrorMessage);
+      }
+
+      return stackRef.current.actions.replace(
+        activityName,
+        activityParams,
+        options,
+      );
+    },
   };
 
   const Stack: StackComponentType = (props) => {
@@ -126,6 +178,6 @@ export function stackflow<T extends BaseActivities>(
   return {
     Stack,
     useFlow: useActions,
-    createStackRef: () => stackRef,
+    actions,
   };
 }


### PR DESCRIPTION
- `stackRef`는 새로운 용어/멘탈모델이고, 불필요한 학습 장벽이 될 수 있습니다.
- 따라서 기존에 활용하던 `actions`라는 용어를 활용해 추상화합니다.