### PR TITLE
fix(plugin-basic-ui): theme can be optional when SSR environment

### DIFF
--- a/extensions/plugin-basic-ui/src/basicUIPlugin.tsx
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.tsx
@@ -15,7 +15,9 @@ type BasicUIPluginOptions = RecursivePartial<theme.GlobalVars> & {
   };
 };
 
-const GlobalOptionsContext = createContext<BasicUIPluginOptions>({
+const GlobalOptionsContext = createContext<
+  BasicUIPluginOptions & { theme: "android" | "cupertino" }
+>({
   theme: "android",
 });
 
@@ -31,7 +33,12 @@ export const basicUIPlugin: (
   key: "basic-ui",
   wrapStack({ stack }) {
     return (
-      <GlobalOptionsProvider value={options}>
+      <GlobalOptionsProvider
+        value={{
+          ...options,
+          theme: options.theme ?? "android",
+        }}
+      >
         <div
           className={options.theme ? theme[options.theme] : undefined}
           style={assignInlineVars(

--- a/extensions/plugin-basic-ui/src/basicUIPlugin.tsx
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.tsx
@@ -7,7 +7,7 @@ import type { RecursivePartial } from "./utils";
 import { compactMap } from "./utils";
 
 type BasicUIPluginOptions = RecursivePartial<theme.GlobalVars> & {
-  theme: "android" | "cupertino";
+  theme?: "android" | "cupertino";
   appBar?: {
     closeButton?: {
       onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
@@ -33,7 +33,7 @@ export const basicUIPlugin: (
     return (
       <GlobalOptionsProvider value={options}>
         <div
-          className={theme[options.theme]}
+          className={options.theme ? theme[options.theme] : undefined}
           style={assignInlineVars(
             compactMap({
               [theme.globalVars.backgroundColor]: options.backgroundColor,

--- a/extensions/plugin-basic-ui/src/theme.css.ts
+++ b/extensions/plugin-basic-ui/src/theme.css.ts
@@ -63,8 +63,11 @@ const cupertinoVars = {
 };
 
 const root = ":root";
-export const rootAndroid = ":root[data-stackflow-basic-ui-theme=android]";
-export const rootCupertino = ":root[data-stackflow-basic-ui-theme=cupertino]";
+
+export const rootAndroid =
+  ":root[data-stackflow-plugin-basic-ui-theme=android]";
+export const rootCupertino =
+  ":root[data-stackflow-plugin-basic-ui-theme=cupertino]";
 
 createGlobalTheme(`${root}, ${rootAndroid}`, globalVars, {
   ...androidVars,

--- a/extensions/plugin-basic-ui/src/theme.css.ts
+++ b/extensions/plugin-basic-ui/src/theme.css.ts
@@ -34,8 +34,6 @@ const defaultVars = {
   dimBackgroundColor: "rgba(0, 0, 0, 0.15)",
   appBar: {
     borderColor: "rgba(0, 0, 0, 0.07)",
-    borderSize: "1px",
-    height: "3.5rem",
     iconColor: "#212124",
     textColor: "#212124",
   },
@@ -47,6 +45,14 @@ const defaultVars = {
   },
 };
 
+const androidVars = {
+  ...defaultVars,
+  appBar: {
+    ...defaultVars.appBar,
+    height: "3.5rem",
+    borderSize: "1px",
+  },
+};
 const cupertinoVars = {
   ...defaultVars,
   appBar: {
@@ -61,14 +67,14 @@ export const rootAndroid = ":root[data-stackflow-basic-ui-theme=android]";
 export const rootCupertino = ":root[data-stackflow-basic-ui-theme=cupertino]";
 
 createGlobalTheme(`${root}, ${rootAndroid}`, globalVars, {
-  ...defaultVars,
+  ...androidVars,
 });
 createGlobalTheme(rootCupertino, globalVars, {
   ...cupertinoVars,
 });
 
 export const android = createTheme(globalVars, {
-  ...defaultVars,
+  ...androidVars,
 });
 export const cupertino = createTheme(globalVars, {
   ...cupertinoVars,


### PR DESCRIPTION
- SSR/SSG 환경에서 theme이 결정적이지 않은 이슈를 해결해요.
- `<html data-stackflow-basic-ui-theme="...">`를 사용하려면, theme을 optional을 넣어야해요.
- `data-stackflow-basic-ui-theme` -> `data-stackflow-plugin-basic-ui-theme`으로 변경해요.