### PR TITLE
refactor(link): rename `createLink` to `createLinkComponent`

### DIFF
--- a/docs/pages/advanced/preloading.ko.mdx
+++ b/docs/pages/advanced/preloading.ko.mdx
@@ -120,17 +120,17 @@ const MyActivity:  = () => {
 $ yarn add @stackflow/link
 ```
 
-`createLink()` 함수를 통해 Type-safe한 Link 컴포넌트를 만들어요.
+`createLinkComponent()` 함수를 통해 Type-safe한 Link 컴포넌트를 만들어요.
 
 ```typescript
 /**
  * Link.ts
  */
-import { createLink } from "@stackflow/link";
+import { createLinkComponent } from "@stackflow/link";
 import type { TypeActivities } from "./stackflow";
 
 // 마찬가지로 액티비티의 전체 타입을 제네릭으로 전달해, Type-safe하게 <Link /> 컴포넌트를 사용해요
-export const { Link } = createLink<TypeActivities>();
+export const { Link } = createLinkComponent<TypeActivities>();
 ```
 
 이후 다음과 같이 `activityName`과 `activityParams`를 Props로 갖는 `<Link />` 컴포넌트를 사용해요.

--- a/extensions/link/README.md
+++ b/extensions/link/README.md
@@ -43,10 +43,10 @@ export type TypeActivities = typeof activities;
 /**
  * Link.ts
  */
-import { createLink } from "@stackflow/link";
+import { createLinkComponent } from "@stackflow/link";
 import type { TypeActivities } from "./stackflow";
 
-export const { Link } = createLink<TypeActivities>();
+export const { Link } = createLinkComponent<TypeActivities>();
 ```
 
 ```tsx

--- a/extensions/link/src/createLinkComponent.tsx
+++ b/extensions/link/src/createLinkComponent.tsx
@@ -1,7 +1,9 @@
 import type { TypeLink } from "./Link";
 import { Link } from "./Link";
 
-export function createLink<T extends { [activityName: string]: unknown }>(): {
+export function createLinkComponent<
+  T extends { [activityName: string]: unknown },
+>(): {
   Link: TypeLink<T>;
 } {
   return {

--- a/extensions/link/src/index.ts
+++ b/extensions/link/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./createLink";
+export * from "./createLinkComponent";
 export * from "./Link";


### PR DESCRIPTION
- 샘플 코드를 훑어보다가 `createLink()`보다는 `createLinkComponent()`라고 명시적으로 하는 편이 더 나은것같아서 이름을 수정했어요