### PR TITLE
chore(preload-plugin): Update pluginPreload to export option typing

### DIFF
--- a/extensions/plugin-preload/src/pluginPreload.tsx
+++ b/extensions/plugin-preload/src/pluginPreload.tsx
@@ -7,7 +7,9 @@ import React from "react";
 import type { Loader } from "./Loader";
 import { LoadersProvider } from "./LoadersContext";
 
-type PreloadPluginOptions<T extends { [activityName: string]: unknown }> = {
+export type PreloadPluginOptions<
+  T extends { [activityName: string]: unknown },
+> = {
   loaders: {
     [key in Extract<keyof T, string>]?: T[key] extends ActivityComponentType<
       infer U


### PR DESCRIPTION
### 설명
- preloadPlugin을 사용하다보니 loaders를 다른 변수로 지정해두고 싶은 니즈가 있었어요.
- 그런데 options typing이 export가 안되어있어서 type을 제대로 잡을 수 없는 문제를 겪어서 해당 type을 export하면 좋겠다고 생각했어요.
- 아래와 같은 예시로 작성하고 싶다고 생각했어요. 혹시 불필요하다고 생각되시면 의견 부탁드려요!

```
const loaders: PreloadPluginOptions<TypeActivities> = {
    ....
}

stackflow({
    ....,
    plugins: [
        ....,
        preloadPlugin({ loaders }),
       ....,
    ]
}

```