### PR TITLE
fix(react): preload with relay

### DIFF
--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -193,7 +193,14 @@ export function historySyncPlugin<
           url: template.fill(rootActivity.params),
           state: {
             _TAG: STATE_TAG,
-            activity: rootActivity,
+            activity: {
+              ...rootActivity,
+              context: undefined,
+              pushedBy: {
+                ...rootActivity.pushedBy,
+                activityContext: undefined,
+              },
+            },
           },
           useHash: options.useHash,
         });
@@ -247,7 +254,14 @@ export function historySyncPlugin<
                 url,
                 state: {
                   _TAG: STATE_TAG,
-                  activity: targetActivity,
+                  activity: {
+                    ...targetActivity,
+                    context: undefined,
+                    pushedBy: {
+                      ...targetActivity.pushedBy,
+                      activityContext: undefined,
+                    },
+                  },
                 },
                 useHash: options.useHash,
               });
@@ -292,7 +306,14 @@ export function historySyncPlugin<
           url: template.fill(activity.params),
           state: {
             _TAG: STATE_TAG,
-            activity,
+            activity: {
+              ...activity,
+              context: undefined,
+              pushedBy: {
+                ...activity.pushedBy,
+                activityContext: undefined,
+              },
+            },
           },
           useHash: options.useHash,
         });
@@ -310,7 +331,14 @@ export function historySyncPlugin<
           url: template.fill(activity.params),
           state: {
             _TAG: STATE_TAG,
-            activity,
+            activity: {
+              ...activity,
+              context: undefined,
+              pushedBy: {
+                ...activity.pushedBy,
+                activityContext: undefined,
+              },
+            },
           },
           useHash: options.useHash,
         });

--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -74,6 +74,20 @@ function replaceState({
   window.history.replaceState(state, "", nextUrl);
 }
 
+/**
+ * Removes activity context before serialization
+ */
+function removeActivityContext(activity: Activity): Activity {
+  return {
+    ...activity,
+    context: undefined,
+    pushedBy: {
+      ...activity.pushedBy,
+      activityContext: undefined,
+    },
+  };
+}
+
 const startTransition: React.TransitionStartFunction =
   React.startTransition ?? ((cb: () => void) => cb());
 
@@ -193,14 +207,7 @@ export function historySyncPlugin<
           url: template.fill(rootActivity.params),
           state: {
             _TAG: STATE_TAG,
-            activity: {
-              ...rootActivity,
-              context: undefined,
-              pushedBy: {
-                ...rootActivity.pushedBy,
-                activityContext: undefined,
-              },
-            },
+            activity: removeActivityContext(rootActivity),
           },
           useHash: options.useHash,
         });
@@ -254,14 +261,7 @@ export function historySyncPlugin<
                 url,
                 state: {
                   _TAG: STATE_TAG,
-                  activity: {
-                    ...targetActivity,
-                    context: undefined,
-                    pushedBy: {
-                      ...targetActivity.pushedBy,
-                      activityContext: undefined,
-                    },
-                  },
+                  activity: removeActivityContext(targetActivity),
                 },
                 useHash: options.useHash,
               });
@@ -306,14 +306,7 @@ export function historySyncPlugin<
           url: template.fill(activity.params),
           state: {
             _TAG: STATE_TAG,
-            activity: {
-              ...activity,
-              context: undefined,
-              pushedBy: {
-                ...activity.pushedBy,
-                activityContext: undefined,
-              },
-            },
+            activity: removeActivityContext(activity),
           },
           useHash: options.useHash,
         });
@@ -331,14 +324,7 @@ export function historySyncPlugin<
           url: template.fill(activity.params),
           state: {
             _TAG: STATE_TAG,
-            activity: {
-              ...activity,
-              context: undefined,
-              pushedBy: {
-                ...activity.pushedBy,
-                activityContext: undefined,
-              },
-            },
+            activity: removeActivityContext(activity),
           },
           useHash: options.useHash,
         });

--- a/integrations/react/src/core/useCoreActions.ts
+++ b/integrations/react/src/core/useCoreActions.ts
@@ -11,8 +11,6 @@ import { useInitContext } from "../init-context";
 import { usePlugins } from "../plugins";
 import { CoreActionsContext } from "./CoreActionsContext";
 
-const copy = (obj: unknown) => JSON.parse(JSON.stringify(obj));
-
 export const useCoreActions = () => {
   const plugins = usePlugins();
   const initContext = useInitContext();
@@ -82,15 +80,20 @@ export const useCoreActions = () => {
   );
 
   const triggerPreEffectHook = useCallback(
-    (preEffect: Effect["_TAG"], initialActionParams: unknown) => {
+    (preEffect: Effect["_TAG"], initialActionParams: any) => {
       let isPrevented = false;
-      let actionParams = copy(initialActionParams);
+      let actionParams = {
+        ...initialActionParams,
+      };
 
       const preventDefault = () => {
         isPrevented = true;
       };
-      const overrideActionParams = (newActionParams: unknown) => {
-        actionParams = copy(newActionParams);
+      const overrideActionParams = (newActionParams: any) => {
+        actionParams = {
+          ...actionParams,
+          ...newActionParams,
+        };
       };
 
       plugins.forEach((plugin) => {


### PR DESCRIPTION
- Activity Context가 Serialize되면서, `preloadRef` 내부의 인스턴스가 날아가는 문제가 발생
- 이를 해결하기 위해, Serialization 로직을 제거하고, `historySyncPlugin`에서 `history.state`를 set하는 부분에서 Activity Context를 제외