### PR TITLE
OS가 다크모드인 경우 docs 글자가 보이지 않는 이슈 수정

### DIFF
--- a/docs/components/Demo.tsx
+++ b/docs/components/Demo.tsx
@@ -1,5 +1,5 @@
 import { Stack } from "@stackflow/demo";
-import React from "react";
+import React, { useEffect } from "react";
 import { useSimpleReveal } from "simple-reveal";
 
 const Demo: React.FC = () => {
@@ -7,6 +7,29 @@ const Demo: React.FC = () => {
     delay: 200,
     initialTransform: "scale(0.95)",
   });
+
+  useEffect(() => {
+    const el = document.documentElement;
+    el.dataset.seed = '';
+
+    const prefersLight = window.matchMedia('(prefers-color-scheme: light)');
+
+    const apply = () => {
+      el.dataset.seedScaleColor = 'light';
+      el.dataset.seedScaleLetterSpacing = 'ios';
+    }
+
+    if (prefersLight.matches) {
+      if ('addEventListener' in prefersLight) {
+        prefersLight.addEventListener('change', apply);
+      } else if ('addListener' in prefersLight) {
+        prefersLight.addListener(apply);
+      }
+    }
+
+    apply();
+  }, [])
+
   return (
     <div
       ref={ref}

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -11,3 +11,9 @@ html {
 .dark .nextra-container > nav.dark\:bg-dark {
   background: rgba(17, 17, 17, 0.5) !important;
 }
+
+@media (prefers-color-scheme: dark) {
+  .nextra-container {
+    color: black;
+  }
+}


### PR DESCRIPTION
AS-IS

<img width="1452" alt="스크린샷 2022-11-12 오후 4 29 13" src="https://user-images.githubusercontent.com/10165823/201462904-3fb6f028-4435-47f6-911e-7399ebfe5551.png">

TO-BE

<img width="1468" alt="스크린샷 2022-11-12 오후 4 28 27" src="https://user-images.githubusercontent.com/10165823/201462909-14d308b2-f0df-402a-9486-fef58ce43a4f.png">

- 다크모드에도 글자색을 검은색으로 강제해요
- Stackflow 데모의 타이틀 글자색도 검은색으로 강제되어서 데모에서는 seed-design 의 라이트 모드를 따라가도록 useEffect 를 호출해요
- seed-design 과 Nextra 간의 theme 불일치가 원인이라고 생각해요.