### PR TITLE
Fix typo on webRendererPlugin.tsx

### DIFF
--- a/extensions/plugin-renderer-web/src/webRendererPlugin.tsx
+++ b/extensions/plugin-renderer-web/src/webRendererPlugin.tsx
@@ -1,7 +1,7 @@
 import type { StackflowReactPlugin } from "@stackflow/react";
 import React from "react";
 
-export function webRednererPlugin(): StackflowReactPlugin {
+export function webRendererPlugin(): StackflowReactPlugin {
   return () => ({
     key: "plugin-renderer-web",
     render({ stack }) {


### PR DESCRIPTION
You can see the typo `webRednererPlugin` (notice `Re"dn"erer`) here.

https://github.com/daangn/stackflow/blob/1ded1f0617b25287576e499be639c74cab6328cd/extensions/plugin-renderer-web/src/webRendererPlugin.tsx#L4

I just fixed the typo.

This change would make a new breaking change here. Any package depends on `stackflow/plugin-renderer-web` will require to take action.