### PR TITLE
fix(docs): Support Dark Mode

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,7 +1,7 @@
 import { Head, Html, Main, NextScript } from "next/document";
 
-const SEED_SCALE_COLOR_SCRIPT = `(() => { var e=document.documentElement;var pd=window.matchMedia("(prefers-color-scheme: dark)"),a= () => { e.dataset.seed="";e.dataset.seedScaleColor=pd.matches?"dark":"light";};"addEventListener"in pd?pd.addEventListener("change",a):"addListener"in pd&&pd.addListener(a),a();})()`;
-const NEXTRA_THEME_SCRIPT = `(() => { var e=document.documentElement;var pd=window.matchMedia("(prefers-color-scheme: dark)"),a= () => { e.classList.remove("light");e.classList.remove("dark");pd.matches ? e.classList.add("dark") : e.classList.add("light");};"addEventListener"in pd?pd.addEventListener("change",a):"addListener"in pd&&pd.addListener(a),a();})()`;
+const SEED_SCALE_COLOR_SCRIPT = `(()=>{var e=document.documentElement,d=window.matchMedia("(prefers-color-scheme: dark)"),a=()=>{e.dataset.seed="",e.dataset.seedScaleColor=d.matches?"dark":"light"};"addEventListener"in d?d.addEventListener("change",a):"addListener"in d&&d.addListener(a),a()})();`;
+const NEXTRA_THEME_SCRIPT = `(()=>{var e=document.documentElement,d=window.matchMedia("(prefers-color-scheme: dark)"),s=()=>{e.classList.remove("light"),e.classList.remove("dark"),d.matches?e.classList.add("dark"):e.classList.add("light")};"addEventListener"in d?d.addEventListener("change",s):"addListener"in d&&d.addListener(s),s()})();`;
 
 export default function Document() {
   return (

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,12 +1,14 @@
 import { Head, Html, Main, NextScript } from "next/document";
 
-const WITH_NEXTRA_SEED_SCALE_COLOR_SCRIPT = `(() => {var e=document.documentElement;e.dataset.seed="";var pd=window.matchMedia("(prefers-color-scheme: dark)"),a=()=>{e.dataset.seedScaleColor=pd.matches?"dark":"light";e.classList.remove("light");e.classList.remove("dark");pd.matches ? e.classList.add("dark") : e.classList.add("light");};"addEventListener"in pd?pd.addEventListener("change",a):"addListener"in pd&&pd.addListener(a),a();})()`;
+const SEED_SCALE_COLOR_SCRIPT = `(() => { var e=document.documentElement;var pd=window.matchMedia("(prefers-color-scheme: dark)"),a= () => { e.dataset.seed="";e.dataset.seedScaleColor=pd.matches?"dark":"light";};"addEventListener"in pd?pd.addEventListener("change",a):"addListener"in pd&&pd.addListener(a),a();})()`;
+const NEXTRA_THEME_SCRIPT = `(() => { var e=document.documentElement;var pd=window.matchMedia("(prefers-color-scheme: dark)"),a= () => { e.classList.remove("light");e.classList.remove("dark");pd.matches ? e.classList.add("dark") : e.classList.add("light");};"addEventListener"in pd?pd.addEventListener("change",a):"addListener"in pd&&pd.addListener(a),a();})()`;
 
 export default function Document() {
   return (
     <Html data-stackflow-plugin-basic-ui-theme="cupertino">
       <Head>
-        <script dangerouslySetInnerHTML={{ __html: WITH_NEXTRA_SEED_SCALE_COLOR_SCRIPT }} />
+        <script dangerouslySetInnerHTML={{ __html: SEED_SCALE_COLOR_SCRIPT }} />
+        <script dangerouslySetInnerHTML={{ __html: NEXTRA_THEME_SCRIPT }} />
       </Head>
       <body>
         <Main />

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,8 +1,6 @@
 import { Head, Html, Main, NextScript } from "next/document";
 
-const SEED_SCALE_COLOR_SCRIPT = `
-  (() => {var e=document.documentElement;e.dataset.seed="";var pd=window.matchMedia("(prefers-color-scheme: dark)"),a=()=>{e.dataset.seedScaleColor=pd.matches?"dark":"light"};"addEventListener"in pd?pd.addEventListener("change",a):"addListener"in pd&&pd.addListener(a),a();})()
-`;
+const SEED_SCALE_COLOR_SCRIPT = `(() => {var e=document.documentElement;e.dataset.seed="";var pd=window.matchMedia("(prefers-color-scheme: dark)"),a=()=>{e.dataset.seedScaleColor=pd.matches?"dark":"light";e.classList.remove("light");e.classList.remove("dark");pd.matches ? e.classList.add("dark") : e.classList.add("light");};"addEventListener"in pd?pd.addEventListener("change",a):"addListener"in pd&&pd.addListener(a),a();})()`;
 
 export default function Document() {
   return (

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,12 +1,12 @@
 import { Head, Html, Main, NextScript } from "next/document";
 
-const SEED_SCALE_COLOR_SCRIPT = `(() => {var e=document.documentElement;e.dataset.seed="";var pd=window.matchMedia("(prefers-color-scheme: dark)"),a=()=>{e.dataset.seedScaleColor=pd.matches?"dark":"light";e.classList.remove("light");e.classList.remove("dark");pd.matches ? e.classList.add("dark") : e.classList.add("light");};"addEventListener"in pd?pd.addEventListener("change",a):"addListener"in pd&&pd.addListener(a),a();})()`;
+const WITH_NEXTRA_SEED_SCALE_COLOR_SCRIPT = `(() => {var e=document.documentElement;e.dataset.seed="";var pd=window.matchMedia("(prefers-color-scheme: dark)"),a=()=>{e.dataset.seedScaleColor=pd.matches?"dark":"light";e.classList.remove("light");e.classList.remove("dark");pd.matches ? e.classList.add("dark") : e.classList.add("light");};"addEventListener"in pd?pd.addEventListener("change",a):"addListener"in pd&&pd.addListener(a),a();})()`;
 
 export default function Document() {
   return (
     <Html data-stackflow-plugin-basic-ui-theme="cupertino">
       <Head>
-        <script dangerouslySetInnerHTML={{ __html: SEED_SCALE_COLOR_SCRIPT }} />
+        <script dangerouslySetInnerHTML={{ __html: WITH_NEXTRA_SEED_SCALE_COLOR_SCRIPT }} />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
a 함수에 다음 코드를 추가하여 사용하는 OS 가 다크모드일 때 `class='dark'` 가 되도록 해서 다크모드를 지원해요

```
e.classList.remove("light");
e.classList.remove("dark");
pd.matches ? e.classList.add("dark") : e.classList.add("light");
```
