### PR TITLE
feat: add bg-color prop to appBar

### DIFF
--- a/extensions/plugin-basic-ui/src/components/AppBar.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppBar.css.ts
@@ -26,6 +26,7 @@ export const appBar = recipe({
     f.contentBox,
     background,
     {
+      backgroundColor: globalVars.appBar.backgroundColor,
       height: globalVars.appBar.height,
       paddingTop: ["constant(safe-area-inset-top)", "env(safe-area-inset-top)"],
       zIndex: vars.zIndexes.appBar,

--- a/extensions/plugin-basic-ui/src/components/AppBar.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppBar.tsx
@@ -14,7 +14,12 @@ import * as appScreenCss from "./AppScreen.css";
 type AppBarProps = Partial<
   Pick<
     GlobalVars["appBar"],
-    "borderColor" | "borderSize" | "height" | "iconColor" | "textColor"
+    | "borderColor"
+    | "borderSize"
+    | "height"
+    | "iconColor"
+    | "textColor"
+    | "backgroundColor"
   >
 > & {
   title?: React.ReactNode;
@@ -54,6 +59,7 @@ const AppBar = React.forwardRef<HTMLDivElement, AppBarProps>(
       borderColor,
       borderSize,
       height,
+      backgroundColor,
     },
     ref,
   ) => {
@@ -195,6 +201,8 @@ const AppBar = React.forwardRef<HTMLDivElement, AppBarProps>(
             [globalVars.appBar.borderColor]: borderColor,
             [globalVars.appBar.borderSize]: borderSize,
             [globalVars.appBar.height]: height,
+            [globalVars.appBar.backgroundColor]:
+              backgroundColor || globalVars.backgroundColor,
             [appScreenCss.vars.appBar.center.mainWidth]: `${maxWidth}px`,
           }),
         )}

--- a/extensions/plugin-basic-ui/src/theme.css.ts
+++ b/extensions/plugin-basic-ui/src/theme.css.ts
@@ -15,6 +15,7 @@ export const globalVars = createGlobalThemeContract(
       height: "app-bar-height",
       iconColor: "app-bar-icon-color",
       textColor: "app-bar-text-color",
+      backgroundColor: "app-bar-background-color",
     },
     bottomSheet: {
       borderRadius: "bottom-sheet-border-radius",
@@ -38,6 +39,7 @@ const defaultVars = {
     height: "3.5rem",
     iconColor: "#212124",
     textColor: "#212124",
+    backgroundColor: "#fff",
   },
   bottomSheet: {
     borderRadius: "1rem",


### PR DESCRIPTION
This change adds `backgroundColor` to AppBar prop
- AppBar's background-color can declaratively be set
- If no prop is passed, use `globalVars.backgroundColor` (for backward compatibility)
