### PR TITLE
refactor(core, react): `create*` to `make*`

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,9 +1,9 @@
 export { aggregate } from "./aggregate";
-export * from "./createCoreStore";
 export { Effect } from "./Effect";
 export * from "./event-types";
 export { DispatchEvent, makeEvent } from "./event-utils";
 export * from "./interfaces";
+export * from "./makeCoreStore";
 export { produceEffects } from "./produceEffects";
 export {
   Activity,

--- a/core/src/makeCoreStore.spec.ts
+++ b/core/src/makeCoreStore.spec.ts
@@ -1,6 +1,6 @@
-import { createCoreStore } from "./createCoreStore";
 import { makeEvent } from "./event-utils";
 import type { StackflowPlugin } from "./interfaces";
+import { makeCoreStore } from "./makeCoreStore";
 import { last } from "./utils";
 
 const SECOND = 1000;
@@ -13,11 +13,11 @@ const enoughPastTime = () => {
   return new Date(Date.now() - MINUTE).getTime() + dt;
 };
 
-test("createCoreStore - beforePush 훅이 정상적으로 동작합니다", () => {
+test("makeCoreStore - beforePush 훅이 정상적으로 동작합니다", () => {
   const onBeforePush = jest.fn();
   const otherHook = jest.fn();
 
-  const { actions } = createCoreStore({
+  const { actions } = makeCoreStore({
     initialEvents: [
       makeEvent("Initialized", {
         transitionDuration: 350,
@@ -54,11 +54,11 @@ test("createCoreStore - beforePush 훅이 정상적으로 동작합니다", () =
   expect(otherHook).toHaveBeenCalledTimes(0);
 });
 
-test("createCoreStore - Pushed 훅이 정상적으로 작동합니다", () => {
+test("makeCoreStore - Pushed 훅이 정상적으로 작동합니다", () => {
   const onPushed = jest.fn();
   const otherHook = jest.fn();
 
-  const { actions } = createCoreStore({
+  const { actions } = makeCoreStore({
     initialEvents: [
       makeEvent("Initialized", {
         transitionDuration: 350,
@@ -98,7 +98,7 @@ test("createCoreStore - Pushed 훅이 정상적으로 작동합니다", () => {
   expect(otherHook).toHaveBeenCalledTimes(0);
 });
 
-test("createCoreStore - onBeforePush 훅에서 preventDefault가 호출되면, 기본 동작을 멈춥니다", () => {
+test("makeCoreStore - onBeforePush 훅에서 preventDefault가 호출되면, 기본 동작을 멈춥니다", () => {
   const onBeforePush: ReturnType<StackflowPlugin>["onBeforePush"] = jest.fn(
     ({ actions }) => {
       actions.preventDefault();
@@ -107,7 +107,7 @@ test("createCoreStore - onBeforePush 훅에서 preventDefault가 호출되면, �
   const onPushed = jest.fn();
   const otherHook = jest.fn();
 
-  const { actions } = createCoreStore({
+  const { actions } = makeCoreStore({
     initialEvents: [
       makeEvent("Initialized", {
         transitionDuration: 350,
@@ -151,12 +151,12 @@ test("createCoreStore - onBeforePush 훅에서 preventDefault가 호출되면, �
   expect(otherHook).toHaveBeenCalledTimes(0);
 });
 
-test("createCoreStore - subscribe에 등록하면, 스택 상태 변경이 있을때 호출됩니다", async () => {
+test("makeCoreStore - subscribe에 등록하면, 스택 상태 변경이 있을때 호출됩니다", async () => {
   const listener1 = jest.fn();
   const listener2 = jest.fn();
   const listener3 = jest.fn();
 
-  const { actions, subscribe } = createCoreStore({
+  const { actions, subscribe } = makeCoreStore({
     initialEvents: [
       makeEvent("Initialized", {
         transitionDuration: 150,
@@ -201,7 +201,7 @@ test("createCoreStore - subscribe에 등록하면, 스택 상태 변경이 있�
   expect(listener3).toHaveBeenCalledTimes(2);
 });
 
-test("createCoreStore - onBeforePush 훅에서 overrideActionParams로 기존 actionParams를 덮어쓸 수 있습니다", () => {
+test("makeCoreStore - onBeforePush 훅에서 overrideActionParams로 기존 actionParams를 덮어쓸 수 있습니다", () => {
   const onBeforePush: ReturnType<StackflowPlugin>["onBeforePush"] = ({
     actions,
     actionParams,
@@ -215,7 +215,7 @@ test("createCoreStore - onBeforePush 훅에서 overrideActionParams로 기존 ac
     });
   };
 
-  const { actions } = createCoreStore({
+  const { actions } = makeCoreStore({
     initialEvents: [
       makeEvent("Initialized", {
         transitionDuration: 350,
@@ -254,10 +254,10 @@ test("createCoreStore - onBeforePush 훅에서 overrideActionParams로 기존 ac
   expect(last(stack.activities)?.params?.hello).toEqual("2");
 });
 
-test("createCoreStore - subscribe에 등록한 이후에 아무 Event가 없는 경우 리스너가 호출되지 않습니다", async () => {
+test("makeCoreStore - subscribe에 등록한 이후에 아무 Event가 없는 경우 리스너가 호출되지 않습니다", async () => {
   const listener1 = jest.fn();
 
-  const { actions, subscribe } = createCoreStore({
+  const { actions, subscribe } = makeCoreStore({
     initialEvents: [
       makeEvent("Initialized", {
         transitionDuration: 150,

--- a/core/src/makeCoreStore.ts
+++ b/core/src/makeCoreStore.ts
@@ -17,21 +17,19 @@ const SECOND = 1000;
 // 60FPS
 const INTERVAL_MS = SECOND / 60;
 
-export type CreateCoreStoreOptions = {
+export type MakeCoreStoreOptions = {
   initialEvents: DomainEvent[];
   plugins: StackflowPlugin[];
 };
 
-export type CreateCoreStoreOutput = {
+export type CoreStore = {
   actions: StackflowActions;
   init: () => void;
   pullEvents: () => DomainEvent[];
   subscribe: (listener: () => void) => () => void;
 };
 
-export function createCoreStore(
-  options: CreateCoreStoreOptions,
-): CreateCoreStoreOutput {
+export function makeCoreStore(options: MakeCoreStoreOptions): CoreStore {
   const events: {
     value: DomainEvent[];
   } = {

--- a/integrations/react/src/core/CoreProvider.tsx
+++ b/integrations/react/src/core/CoreProvider.tsx
@@ -1,15 +1,15 @@
-import type { Stack, CreateCoreStoreOutput } from "@stackflow/core";
+import type { CoreStore, Stack } from "@stackflow/core";
 import React, { createContext } from "react";
 
 import { useDeferredValue, useSyncExternalStore } from "../shims";
 
-export const CoreActionsContext = createContext<
-  CreateCoreStoreOutput["actions"]
->(null as any);
+export const CoreActionsContext = createContext<CoreStore["actions"]>(
+  null as any,
+);
 export const CoreStateContext = createContext<Stack>(null as any);
 
 export interface CoreProviderProps {
-  coreStore: CreateCoreStoreOutput;
+  coreStore: CoreStore;
   children: React.ReactNode;
 }
 export const CoreProvider: React.FC<CoreProviderProps> = ({

--- a/integrations/react/src/stackflow.tsx
+++ b/integrations/react/src/stackflow.tsx
@@ -1,10 +1,11 @@
 import type {
   ActivityRegisteredEvent,
+  CoreStore,
   PushedEvent,
   StackflowActions,
   StepPushedEvent,
 } from "@stackflow/core";
-import { createCoreStore, makeEvent } from "@stackflow/core";
+import { makeCoreStore, makeEvent } from "@stackflow/core";
 import React, { useEffect, useMemo } from "react";
 
 import type { ActivityComponentType } from "./activity";
@@ -21,7 +22,7 @@ import type {
   UseStepActionsOutputType,
 } from "./useStepActions";
 import { useStepActions } from "./useStepActions";
-import { createRef } from "./utils";
+import { makeRef } from "./utils";
 
 function parseActionOptions(options?: { animate?: boolean }) {
   if (!options) {
@@ -148,7 +149,7 @@ export function stackflow<T extends BaseActivities>(
   const enoughPastTime = () =>
     new Date().getTime() - options.transitionDuration * 2;
 
-  const staticCoreStore = createCoreStore({
+  const staticCoreStore = makeCoreStore({
     initialEvents: [
       makeEvent("Initialized", {
         transitionDuration: options.transitionDuration,
@@ -169,8 +170,7 @@ export function stackflow<T extends BaseActivities>(
     plugins: [],
   });
 
-  const [getCoreStore, setCoreStore] =
-    createRef<ReturnType<typeof createCoreStore>>();
+  const [getCoreStore, setCoreStore] = makeRef<CoreStore>();
 
   const Stack: StackComponentType = (props) => {
     const coreStore = useMemo(() => {
@@ -222,7 +222,7 @@ export function stackflow<T extends BaseActivities>(
         );
       }
 
-      const store = createCoreStore({
+      const store = makeCoreStore({
         initialEvents: [
           ...staticCoreStore.pullEvents(),
           ...initialPushedEvents,

--- a/integrations/react/src/utils/index.ts
+++ b/integrations/react/src/utils/index.ts
@@ -1,3 +1,3 @@
-export * from "./createRef";
+export * from "./makeRef";
 export * from "./useMemoDeep";
 export * from "./WithRequired";

--- a/integrations/react/src/utils/makeRef.ts
+++ b/integrations/react/src/utils/makeRef.ts
@@ -1,4 +1,4 @@
-export function createRef<T>(): [() => T | null, (value: T) => void] {
+export function makeRef<T>(): [() => T | null, (value: T) => void] {
   const ref: {
     value: T | null;
   } = {


### PR DESCRIPTION
- 내부에서 사용하는 Object들의 초기화 함수를 `make*`로 통일해요.
  - 기존에 `makeEvent` 등 대부분 통일되어 있었는데, 통일되지 않은 API들을 통일했어요.