### PR TITLE
fix(react): init coreStore right after `makeCoreStore()`

### DIFF
--- a/integrations/react/src/stackflow.tsx
+++ b/integrations/react/src/stackflow.tsx
@@ -230,14 +230,14 @@ export function stackflow<T extends BaseActivities>(
         plugins,
       });
 
+      if (typeof window !== "undefined") {
+        store.init();
+      }
+
       setCoreStore(store);
 
       return store;
     }, []);
-
-    useEffect(() => {
-      coreStore.init();
-    }, [coreStore]);
 
     return (
       <PluginsProvider value={pluginInstances}>


### PR DESCRIPTION
`store.init()`과 Activity 렌더링의 실행 순서를 보장합니다.