### PR TITLE
feat(plugin-basic-ui): `<AppScreen ref={...} />`

### DIFF
--- a/extensions/plugin-basic-ui/src/components/AppBar.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppBar.css.ts
@@ -21,7 +21,7 @@ const minHeight = style({
   minHeight: globalVars.appBar.minHeight,
 });
 
-export const appBar = recipe({
+export const container = recipe({
   base: [
     f.posAbs,
     f.fullWidth,
@@ -67,7 +67,7 @@ export const safeArea = style({
   height: ["constant(safe-area-inset-top)", "env(safe-area-inset-top)"],
 });
 
-export const container = style([
+export const bar = style([
   f.flexAlignEnd,
   f.overflowHidden,
   {

--- a/extensions/plugin-basic-ui/src/components/AppBar.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppBar.tsx
@@ -193,7 +193,7 @@ const AppBar = React.forwardRef<HTMLDivElement, AppBarProps>(
     return (
       <div
         ref={ref}
-        className={css.appBar({
+        className={css.container({
           border,
         })}
         style={assignInlineVars(
@@ -210,7 +210,7 @@ const AppBar = React.forwardRef<HTMLDivElement, AppBarProps>(
         )}
       >
         <div className={css.safeArea} />
-        <div className={css.container}>
+        <div className={css.bar}>
           <div className={css.left}>
             {closeButtonLocation === "left" && renderCloseButton()}
             {renderBackButton()}

--- a/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
@@ -44,7 +44,7 @@ export const exitDone = style({
   transform: "translateX(100%)",
 });
 
-export const appScreen = recipe({
+export const container = recipe({
   base: [f.posAbsFull, f.overflowHidden],
   variants: {
     transitionState: {
@@ -84,7 +84,7 @@ export const dim = style([
   },
 ]);
 
-export const paper = recipe({
+export const main = recipe({
   base: [
     f.posAbsFull,
     background,

--- a/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
@@ -14,7 +14,7 @@ export const vars = createThemeContract({
   transitionDuration: null,
   zIndexes: {
     dim: null,
-    paper: null,
+    main: null,
     edge: null,
     appBar: null,
   },
@@ -95,7 +95,7 @@ export const main = recipe({
       "::-webkit-scrollbar": {
         display: "none",
       },
-      zIndex: vars.zIndexes.paper,
+      zIndex: vars.zIndexes.main,
       selectors: {
         [`${cupertino} &, ${rootCupertino} &`]: {
           transform: "translateX(100%)",

--- a/extensions/plugin-basic-ui/src/components/AppScreen.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.tsx
@@ -66,7 +66,7 @@ const AppScreen = React.forwardRef<HTMLDivElement, AppScreenProps>(
 
     const zIndexBase = (activity?.zIndex ?? 0) * 5;
     const zIndexDim = zIndexBase;
-    const zIndexPaper =
+    const zIndexMain =
       zIndexBase + (globalOptions.theme === "cupertino" && hasAppBar ? 1 : 3);
     const zIndexEdge = zIndexBase + 4;
     const zIndexAppBar = zIndexBase + 7;
@@ -102,7 +102,7 @@ const AppScreen = React.forwardRef<HTMLDivElement, AppScreenProps>(
             [globalVars.appBar.heightTransitionDuration]:
               props.appBar?.heightTransitionDuration,
             [css.vars.zIndexes.dim]: `${zIndexDim}`,
-            [css.vars.zIndexes.main]: `${zIndexPaper}`,
+            [css.vars.zIndexes.main]: `${zIndexMain}`,
             [css.vars.zIndexes.edge]: `${zIndexEdge}`,
             [css.vars.zIndexes.appBar]: `${zIndexAppBar}`,
             [css.vars.transitionDuration]:

--- a/extensions/plugin-basic-ui/src/components/AppScreen.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.tsx
@@ -102,7 +102,7 @@ const AppScreen = React.forwardRef<HTMLDivElement, AppScreenProps>(
             [globalVars.appBar.heightTransitionDuration]:
               props.appBar?.heightTransitionDuration,
             [css.vars.zIndexes.dim]: `${zIndexDim}`,
-            [css.vars.zIndexes.paper]: `${zIndexPaper}`,
+            [css.vars.zIndexes.main]: `${zIndexPaper}`,
             [css.vars.zIndexes.edge]: `${zIndexEdge}`,
             [css.vars.zIndexes.appBar]: `${zIndexAppBar}`,
             [css.vars.transitionDuration]:

--- a/extensions/plugin-basic-ui/src/components/AppScreen.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.tsx
@@ -34,7 +34,7 @@ const AppScreen = React.forwardRef<HTMLDivElement, AppScreenProps>(
     const activity = useNullableActivity();
     const { pop } = useActions();
 
-    const rootRef = useRef<HTMLDivElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
     const dimRef = useRef<HTMLDivElement>(null);
     const edgeRef = useRef<HTMLDivElement>(null);
     const appBarRef = useRef<HTMLDivElement>(null);
@@ -42,7 +42,7 @@ const AppScreen = React.forwardRef<HTMLDivElement, AppScreenProps>(
     const mainRef = useForwardedRef(ref);
 
     useStyleEffectHide({
-      refs: [rootRef],
+      refs: [containerRef],
       hasEffect: true,
     });
     useStyleEffectOffset({
@@ -87,7 +87,7 @@ const AppScreen = React.forwardRef<HTMLDivElement, AppScreenProps>(
 
     return (
       <div
-        ref={rootRef}
+        ref={containerRef}
         className={css.container({
           transitionState:
             transitionState === "enter-done" || transitionState === "exit-done"

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.css.ts
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.css.ts
@@ -8,7 +8,7 @@ export const vars = createThemeContract({
   transitionDuration: null,
   zIndexes: {
     dim: null,
-    paper: null,
+    main: null,
   },
 });
 

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.css.ts
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.css.ts
@@ -55,7 +55,7 @@ export const dim = style([
   },
 ]);
 
-export const paper = style([
+export const main = style([
   f.overflowHidden,
   allTransitions,
   {

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
@@ -89,7 +89,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
       )}
     >
       <div className={css.dim} ref={paperRef} onClick={onDimClick}>
-        <div className={css.paper} onClick={onPaperClick}>
+        <div className={css.main} onClick={onPaperClick}>
           {children}
         </div>
       </div>

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
@@ -28,7 +28,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
   const { pop } = useActions();
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const paperRef = useRef<HTMLDivElement>(null);
+  const mainRef = useRef<HTMLDivElement>(null);
 
   useStyleEffect({
     styleName: "hide",
@@ -36,11 +36,11 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
   });
   useStyleEffect({
     styleName: "offset",
-    refs: [paperRef],
+    refs: [mainRef],
   });
   useStyleEffect({
     styleName: "swipe-back",
-    refs: [paperRef],
+    refs: [mainRef],
   });
 
   const popLock = useRef(false);
@@ -88,8 +88,8 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
         }),
       )}
     >
-      <div className={css.dim} ref={paperRef} onClick={onDimClick}>
-        <div className={css.main} onClick={onPaperClick}>
+      <div className={css.dim} onClick={onDimClick}>
+        <div className={css.main} ref={mainRef} onClick={onPaperClick}>
           {children}
         </div>
       </div>

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
@@ -64,7 +64,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
   };
 
   const zIndexBase = (activity?.zIndex ?? 0) * 5 + 3;
-  const zIndexPaper = (activity?.zIndex ?? 0) * 5 + 4;
+  const zIndexMain = (activity?.zIndex ?? 0) * 5 + 4;
   const transitionState = activity?.transitionState ?? "enter-done";
 
   return (
@@ -79,7 +79,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
           [globalVars.backgroundColor]: backgroundColor,
           [globalVars.dimBackgroundColor]: dimBackgroundColor,
           [css.vars.zIndexes.dim]: `${zIndexBase}`,
-          [css.vars.zIndexes.main]: `${zIndexPaper}`,
+          [css.vars.zIndexes.main]: `${zIndexMain}`,
           [css.vars.transitionDuration]:
             transitionState === "enter-active" ||
             transitionState === "exit-active"

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
@@ -59,7 +59,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
 
     pop();
   };
-  const onPaperClick: React.MouseEventHandler = (e) => {
+  const onMainClick: React.MouseEventHandler = (e) => {
     e.stopPropagation();
   };
 
@@ -79,7 +79,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
           [globalVars.backgroundColor]: backgroundColor,
           [globalVars.dimBackgroundColor]: dimBackgroundColor,
           [css.vars.zIndexes.dim]: `${zIndexBase}`,
-          [css.vars.zIndexes.paper]: `${zIndexPaper}`,
+          [css.vars.zIndexes.main]: `${zIndexPaper}`,
           [css.vars.transitionDuration]:
             transitionState === "enter-active" ||
             transitionState === "exit-active"
@@ -89,7 +89,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
       )}
     >
       <div className={css.dim} onClick={onDimClick}>
-        <div className={css.main} ref={mainRef} onClick={onPaperClick}>
+        <div className={css.main} ref={mainRef} onClick={onMainClick}>
           {children}
         </div>
       </div>

--- a/extensions/plugin-basic-ui/src/components/Modal.css.ts
+++ b/extensions/plugin-basic-ui/src/components/Modal.css.ts
@@ -8,7 +8,7 @@ export const vars = createThemeContract({
   transitionDuration: null,
   zIndexes: {
     dim: null,
-    paper: null,
+    main: null,
   },
 });
 

--- a/extensions/plugin-basic-ui/src/components/Modal.css.ts
+++ b/extensions/plugin-basic-ui/src/components/Modal.css.ts
@@ -56,7 +56,7 @@ export const dim = style([
   },
 ]);
 
-export const paper = style([
+export const main = style([
   f.overflowHidden,
   allTransitions,
   {

--- a/extensions/plugin-basic-ui/src/components/Modal.tsx
+++ b/extensions/plugin-basic-ui/src/components/Modal.tsx
@@ -64,7 +64,7 @@ const Modal: React.FC<ModalProps> = ({
   };
 
   const zIndexBase = (activity?.zIndex ?? 0) * 5 + 3;
-  const zIndexPaper = (activity?.zIndex ?? 0) * 5 + 4;
+  const zIndexMain = (activity?.zIndex ?? 0) * 5 + 4;
   const transitionState = activity?.transitionState ?? "enter-done";
 
   return (
@@ -79,7 +79,7 @@ const Modal: React.FC<ModalProps> = ({
           [globalVars.backgroundColor]: backgroundColor,
           [globalVars.dimBackgroundColor]: dimBackgroundColor,
           [css.vars.zIndexes.dim]: `${zIndexBase}`,
-          [css.vars.zIndexes.main]: `${zIndexPaper}`,
+          [css.vars.zIndexes.main]: `${zIndexMain}`,
           [css.vars.transitionDuration]:
             transitionState === "enter-active" ||
             transitionState === "exit-active"

--- a/extensions/plugin-basic-ui/src/components/Modal.tsx
+++ b/extensions/plugin-basic-ui/src/components/Modal.tsx
@@ -28,7 +28,7 @@ const Modal: React.FC<ModalProps> = ({
   const { pop } = useActions();
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const paperRef = useRef<HTMLDivElement>(null);
+  const mainRef = useRef<HTMLDivElement>(null);
 
   useStyleEffect({
     styleName: "hide",
@@ -36,11 +36,11 @@ const Modal: React.FC<ModalProps> = ({
   });
   useStyleEffect({
     styleName: "offset",
-    refs: [paperRef],
+    refs: [mainRef],
   });
   useStyleEffect({
     styleName: "swipe-back",
-    refs: [paperRef],
+    refs: [mainRef],
   });
 
   const popLock = useRef(false);
@@ -88,8 +88,8 @@ const Modal: React.FC<ModalProps> = ({
         }),
       )}
     >
-      <div className={css.dim} ref={paperRef} onClick={onDimClick}>
-        <div className={css.main} onClick={onPaperClick}>
+      <div className={css.dim} onClick={onDimClick}>
+        <div className={css.main} ref={mainRef} onClick={onPaperClick}>
           {children}
         </div>
       </div>

--- a/extensions/plugin-basic-ui/src/components/Modal.tsx
+++ b/extensions/plugin-basic-ui/src/components/Modal.tsx
@@ -59,7 +59,7 @@ const Modal: React.FC<ModalProps> = ({
 
     pop();
   };
-  const onPaperClick: React.MouseEventHandler = (e) => {
+  const onMainClick: React.MouseEventHandler = (e) => {
     e.stopPropagation();
   };
 
@@ -79,7 +79,7 @@ const Modal: React.FC<ModalProps> = ({
           [globalVars.backgroundColor]: backgroundColor,
           [globalVars.dimBackgroundColor]: dimBackgroundColor,
           [css.vars.zIndexes.dim]: `${zIndexBase}`,
-          [css.vars.zIndexes.paper]: `${zIndexPaper}`,
+          [css.vars.zIndexes.main]: `${zIndexPaper}`,
           [css.vars.transitionDuration]:
             transitionState === "enter-active" ||
             transitionState === "exit-active"
@@ -89,7 +89,7 @@ const Modal: React.FC<ModalProps> = ({
       )}
     >
       <div className={css.dim} onClick={onDimClick}>
-        <div className={css.main} ref={mainRef} onClick={onPaperClick}>
+        <div className={css.main} ref={mainRef} onClick={onMainClick}>
           {children}
         </div>
       </div>

--- a/extensions/plugin-basic-ui/src/components/Modal.tsx
+++ b/extensions/plugin-basic-ui/src/components/Modal.tsx
@@ -89,7 +89,7 @@ const Modal: React.FC<ModalProps> = ({
       )}
     >
       <div className={css.dim} ref={paperRef} onClick={onDimClick}>
-        <div className={css.paper} onClick={onPaperClick}>
+        <div className={css.main} onClick={onPaperClick}>
           {children}
         </div>
       </div>

--- a/extensions/plugin-basic-ui/src/hooks/index.ts
+++ b/extensions/plugin-basic-ui/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from "./useForwardedRef";
 export * from "./useLazy";
 export * from "./useMaxWidth";
 export * from "./useNullableActivity";

--- a/extensions/plugin-basic-ui/src/hooks/useForwardedRef.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useForwardedRef.ts
@@ -1,24 +1,11 @@
 import type React from "react";
-import { useEffect, useRef } from "react";
+import { useImperativeHandle, useRef } from "react";
 
 export function useForwardedRef<T>(
   ref: React.ForwardedRef<T>,
 ): React.RefObject<T> {
   const innerRef = useRef<T>(null);
-
-  useEffect(() => {
-    if (!ref) {
-      return;
-    }
-
-    if (typeof ref === "function") {
-      ref(innerRef.current);
-      return;
-    }
-
-    // eslint-disable-next-line no-param-reassign
-    ref.current = innerRef.current;
-  }, [ref, innerRef]);
+  useImperativeHandle<T | null, T | null>(ref, () => innerRef.current);
 
   return innerRef;
 }

--- a/extensions/plugin-basic-ui/src/hooks/useForwardedRef.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useForwardedRef.ts
@@ -1,0 +1,24 @@
+import type React from "react";
+import { useEffect, useRef } from "react";
+
+export function useForwardedRef<T>(
+  ref: React.ForwardedRef<T>,
+): React.RefObject<T> {
+  const innerRef = useRef<T>(null);
+
+  useEffect(() => {
+    if (!ref) {
+      return;
+    }
+
+    if (typeof ref === "function") {
+      ref(innerRef.current);
+      return;
+    }
+
+    // eslint-disable-next-line no-param-reassign
+    ref.current = innerRef.current;
+  }, [ref, innerRef]);
+
+  return innerRef;
+}

--- a/extensions/plugin-basic-ui/src/hooks/useStyleEffect.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useStyleEffect.ts
@@ -20,7 +20,7 @@ export function useStyleEffect({
   effect,
 }: {
   styleName: string;
-  refs: Array<React.RefObject<any>>;
+  refs: Array<React.RefObject<any> | React.MutableRefObject<any>>;
   effect?: (params: {
     activityTransitionState: ActivityTransitionState;
     refs: Array<React.RefObject<HTMLElement>>;

--- a/extensions/plugin-basic-ui/src/hooks/useStyleEffectOffset.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useStyleEffectOffset.ts
@@ -11,7 +11,7 @@ export function useStyleEffectOffset({
   theme,
   hasEffect,
 }: {
-  refs: Array<React.RefObject<any>>;
+  refs: Array<React.RefObject<any> | React.MutableRefObject<any>>;
   theme: "android" | "cupertino";
   hasEffect?: boolean;
 }) {

--- a/extensions/plugin-basic-ui/src/hooks/useStyleEffectSwipeBack.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useStyleEffectSwipeBack.ts
@@ -34,7 +34,7 @@ export function useStyleEffectSwipeBack({
 
           const $dim = dimRef.current;
           const $edge = edgeRef.current;
-          const $paper = mainRef.current;
+          const $main = mainRef.current;
 
           let x0: number | null = null;
           let t0: number | null = null;
@@ -66,14 +66,14 @@ export function useStyleEffectSwipeBack({
               _rAFLock = true;
 
               requestAnimationFrame(() => {
-                const p = dx / $paper.clientWidth;
+                const p = dx / $main.clientWidth;
 
                 $dim.style.opacity = `${1 - p}`;
                 $dim.style.transition = "0s";
 
-                $paper.style.overflowY = "hidden";
-                $paper.style.transform = `translateX(${dx}px)`;
-                $paper.style.transition = "0s";
+                $main.style.overflowY = "hidden";
+                $main.style.transform = `translateX(${dx}px)`;
+                $main.style.transition = "0s";
 
                 refs.forEach((ref) => {
                   if (!ref.current) {
@@ -101,10 +101,9 @@ export function useStyleEffectSwipeBack({
                 $dim.style.opacity = `${swiped ? 0 : 1}`;
                 $dim.style.transition = "var(--stackflow-transition-duration)";
 
-                $paper.style.overflowY = "hidden";
-                $paper.style.transform = `translateX(${swiped ? "100%" : "0"})`;
-                $paper.style.transition =
-                  "var(--stackflow-transition-duration)";
+                $main.style.overflowY = "hidden";
+                $main.style.transform = `translateX(${swiped ? "100%" : "0"})`;
+                $main.style.transition = "var(--stackflow-transition-duration)";
 
                 refs.forEach((ref) => {
                   if (!ref.current) {
@@ -121,10 +120,10 @@ export function useStyleEffectSwipeBack({
 
                 resolve();
 
-                listenOnce($paper, "transitionend", () => {
+                listenOnce($main, "transitionend", () => {
                   $dim.style.opacity = "";
-                  $paper.style.overflowY = "";
-                  $paper.style.transform = "";
+                  $main.style.overflowY = "";
+                  $main.style.transform = "";
 
                   refs.forEach((ref, i) => {
                     if (!ref.current) {
@@ -212,7 +211,7 @@ export function useStyleEffectSwipeBack({
 
             const t = Date.now();
             const v = (x - x0) / (t - t0);
-            const swiped = v > 1 || x / $paper.clientWidth > 0.4;
+            const swiped = v > 1 || x / $main.clientWidth > 0.4;
 
             if (swiped) {
               onSwiped?.();

--- a/extensions/plugin-basic-ui/src/hooks/useStyleEffectSwipeBack.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useStyleEffectSwipeBack.ts
@@ -8,33 +8,33 @@ export function useStyleEffectSwipeBack({
   theme,
   dimRef,
   edgeRef,
-  paperRef,
+  mainRef,
   hasEffect,
   onSwiped,
 }: {
   theme: "android" | "cupertino";
   dimRef: React.RefObject<HTMLDivElement>;
   edgeRef: React.RefObject<HTMLDivElement>;
-  paperRef: React.RefObject<HTMLDivElement>;
+  mainRef: React.RefObject<HTMLDivElement>;
   hasEffect?: boolean;
   onSwiped?: () => void;
 }) {
   useStyleEffect({
     styleName: "swipe-back",
-    refs: [paperRef],
+    refs: [mainRef],
     effect: hasEffect
       ? ({ refs }) => {
           if (theme !== "cupertino") {
             return () => {};
           }
 
-          if (!dimRef.current || !edgeRef.current || !paperRef.current) {
+          if (!dimRef.current || !edgeRef.current || !mainRef.current) {
             return () => {};
           }
 
           const $dim = dimRef.current;
           const $edge = edgeRef.current;
-          const $paper = paperRef.current;
+          const $paper = mainRef.current;
 
           let x0: number | null = null;
           let t0: number | null = null;

--- a/extensions/plugin-basic-ui/src/hooks/useStyleEffectSwipeBack.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useStyleEffectSwipeBack.ts
@@ -61,7 +61,7 @@ export function useStyleEffectSwipeBack({
 
           let _rAFLock = false;
 
-          function movePaper(dx: number) {
+          function moveMain(dx: number) {
             if (!_rAFLock) {
               _rAFLock = true;
 
@@ -95,7 +95,7 @@ export function useStyleEffectSwipeBack({
             }
           }
 
-          function resetPaper({ swiped }: { swiped: boolean }): Promise<void> {
+          function resetMain({ swiped }: { swiped: boolean }): Promise<void> {
             return new Promise((resolve) => {
               requestAnimationFrame(() => {
                 $dim.style.opacity = `${swiped ? 0 : 1}`;
@@ -200,7 +200,7 @@ export function useStyleEffectSwipeBack({
 
             x = e.touches[0].clientX;
 
-            movePaper(x - x0);
+            moveMain(x - x0);
           };
 
           const onTouchEnd = () => {
@@ -218,7 +218,7 @@ export function useStyleEffectSwipeBack({
             }
 
             Promise.resolve()
-              .then(() => resetPaper({ swiped }))
+              .then(() => resetMain({ swiped }))
               .then(() => resetState());
           };
 


### PR DESCRIPTION
- `ref.current.scroll({ top: 0 })`을 하기 위해서 ref를 노출해요.
- dimRef, edgeRef, appBarRef, paperRef를 다 노출하려다가, 생각해보니 paperRef만 노출이 필요할 것 같아서, 해당하는 부분만 forwardRef로 간결하게 뺐어요.
- 컨셉을 조정하는 김에 CSS 네이밍을 바꿨어요.