### PR TITLE
feat(feat): useEnterDoneEffect

### DIFF
--- a/integrations/react/src/index.ts
+++ b/integrations/react/src/index.ts
@@ -6,4 +6,5 @@ export * from "./stackflow";
 export * from "./StackflowReactPlugin";
 export * from "./useActions";
 export * from "./useActiveEffect";
+export * from "./useEnterDoneEffect";
 export * from "./useStepActions";

--- a/integrations/react/src/useEnterDoneEffect.ts
+++ b/integrations/react/src/useEnterDoneEffect.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+import { useActivity } from "./activity/useActivity";
+
+const useEnterDoneEffect = (
+  effect: React.EffectCallback,
+  deps: React.DependencyList = [],
+) => {
+  const { isTop, transitionState } = useActivity();
+
+  useEffect(() => {
+    if (isTop && transitionState === "enter-done") {
+      return effect();
+    }
+  }, [isTop, transitionState, ...deps]);
+};
+
+export default useEnterDoneEffect;


### PR DESCRIPTION
## 배경

- activity가 올라왔지만 transition이 완료되지 않았을 때 keypad를 올리거나 animation을 발생시키면 layout이 깨지는 경우가 있어 activity가 위로 올라오고 transition이 완료되었을 때 수행하도록 하는 훅을 추가해줬어요.