### PR TITLE
refactor(react): move `useTransition` shim to separate file

### DIFF
--- a/integrations/react/src/shims/index.ts
+++ b/integrations/react/src/shims/index.ts
@@ -1,2 +1,3 @@
 export * from "./useDeferredValue";
 export * from "./useSyncExternalStore";
+export * from "./useTransition";

--- a/integrations/react/src/shims/useTransition.ts
+++ b/integrations/react/src/shims/useTransition.ts
@@ -1,0 +1,4 @@
+import React from "react";
+
+export const useTransition: typeof React.useTransition =
+  React.useTransition ?? (() => [false, (cb: () => void) => cb()]);

--- a/integrations/react/src/useActions.ts
+++ b/integrations/react/src/useActions.ts
@@ -4,6 +4,7 @@ import type { ActivityComponentType } from "./activity";
 import { makeActivityId } from "./activity";
 import type { BaseActivities } from "./BaseActivities";
 import { useCoreActions } from "./core";
+import { useTransition } from "./shims";
 
 function parseActionOptions(options?: { animate?: boolean }) {
   if (!options) {
@@ -65,9 +66,6 @@ export type UseActionsOutputType<T extends BaseActivities> = {
    */
   pop: (options?: { animate?: boolean }) => void;
 };
-
-const useTransition: () => [boolean, React.TransitionStartFunction] =
-  React.useTransition ?? (() => [false, (cb: () => void) => cb()]);
 
 export function useActions<
   T extends BaseActivities,

--- a/integrations/react/src/useStepActions.ts
+++ b/integrations/react/src/useStepActions.ts
@@ -4,6 +4,7 @@ import type { ActivityComponentType } from "./activity";
 import { makeStepId } from "./activity";
 import type { BaseActivities } from "./BaseActivities";
 import { useCoreActions } from "./core";
+import { useTransition } from "./shims";
 
 export type UseStepActionsOutputType<P> = {
   pending: boolean;
@@ -23,9 +24,6 @@ export type UseStepActions<T extends BaseActivities = {}> = <
     ? U
     : {}
 >;
-
-const useTransition: () => [boolean, React.TransitionStartFunction] =
-  React.useTransition ?? (() => [false, (cb: () => void) => cb()]);
 
 export const useStepActions: UseStepActions = () => {
   const coreActions = useCoreActions();


### PR DESCRIPTION
- `useTransition` fallback을 `src/shims` 내 별도의 파일로 분리하고, 사용처에서 이를 사용하도록 변경했어요.