### PR TITLE
refactor(plugin-basic-ui): refobject using generics

### DIFF
--- a/extensions/plugin-basic-ui/src/hooks/useStyleEffect.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useStyleEffect.ts
@@ -1,5 +1,5 @@
 import type { ActivityTransitionState } from "@stackflow/core";
-import type React from "react";
+import type { RefObject } from "react";
 import { useEffect } from "react";
 
 import { useNullableActivity } from "./useNullableActivity";
@@ -8,23 +8,23 @@ const connections: {
   [styleName: string]: Map<
     number,
     {
-      refs: Array<React.RefObject<any>>;
+      refs: Array<RefObject<any>>;
       hasEffect: boolean;
     }
   >;
 } = {};
 
-export function useStyleEffect({
+export function useStyleEffect<T extends HTMLElement>({
   styleName,
   refs,
   effect,
   effectDeps,
 }: {
   styleName: string;
-  refs: Array<React.RefObject<any>>;
+  refs: Array<RefObject<T>>;
   effect?: (params: {
     activityTransitionState: ActivityTransitionState;
-    refs: Array<React.RefObject<HTMLElement>>;
+    refs: Array<RefObject<T>>;
   }) => (() => void) | void;
   effectDeps?: any[];
 }) {
@@ -57,7 +57,7 @@ export function useStyleEffect({
     }
 
     const refs = (() => {
-      let arr: Array<React.RefObject<any>> = [];
+      let arr: Array<RefObject<T>> = [];
 
       for (let i = 1; i <= activity.zIndex; i += 1) {
         const connection = connections[styleName].get(activity.zIndex - i);

--- a/extensions/plugin-basic-ui/src/hooks/useStyleEffect.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useStyleEffect.ts
@@ -1,5 +1,5 @@
 import type { ActivityTransitionState } from "@stackflow/core";
-import type { RefObject } from "react";
+import type React from "react";
 import { useEffect } from "react";
 
 import { useNullableActivity } from "./useNullableActivity";
@@ -8,7 +8,7 @@ const connections: {
   [styleName: string]: Map<
     number,
     {
-      refs: Array<RefObject<any>>;
+      refs: Array<React.RefObject<any>>;
       hasEffect: boolean;
     }
   >;
@@ -21,10 +21,10 @@ export function useStyleEffect<T extends HTMLElement>({
   effectDeps,
 }: {
   styleName: string;
-  refs: Array<RefObject<T>>;
+  refs: Array<React.RefObject<T>>;
   effect?: (params: {
     activityTransitionState: ActivityTransitionState;
-    refs: Array<RefObject<T>>;
+    refs: Array<React.RefObject<T>>;
   }) => (() => void) | void;
   effectDeps?: any[];
 }) {
@@ -57,7 +57,7 @@ export function useStyleEffect<T extends HTMLElement>({
     }
 
     const refs = (() => {
-      let arr: Array<RefObject<T>> = [];
+      let arr: Array<React.RefObject<T>> = [];
 
       for (let i = 1; i <= activity.zIndex; i += 1) {
         const connection = connections[styleName].get(activity.zIndex - i);


### PR DESCRIPTION
제네릭을 사용해 any를 지우고 흩어져있던 타입들을 하나로 관리해요. ~~그리고 RefObject를 구체적으로 가져옵니다.~~