### PR TITLE
refactor(core): findTargetActivityIndexes

### DIFF
--- a/core/src/activity-utils/findTargetActivityIndexes.ts
+++ b/core/src/activity-utils/findTargetActivityIndexes.ts
@@ -5,6 +5,7 @@ import { findIndices, last } from "../utils";
 function isActivityNotExited(activity: Activity) {
   return !activity.exitedBy;
 }
+
 function compareActivitiesByEventDate(a1: Activity, a2: Activity) {
   return a2.enteredBy.eventDate - a1.enteredBy.eventDate;
 }

--- a/core/src/activity-utils/findTargetActivityIndexes.ts
+++ b/core/src/activity-utils/findTargetActivityIndexes.ts
@@ -6,14 +6,14 @@ function isActivityNotExited(activity: Activity) {
   return !activity.exitedBy;
 }
 
-function sortActivitiesByEventDate(a1: Activity, a2: Activity) {
+function compareActivitiesByEventDate(a1: Activity, a2: Activity) {
   return a2.enteredBy.eventDate - a1.enteredBy.eventDate;
 }
 
 function findLatestActiveActivity(activities: Activity[]) {
   return activities
     .filter(isActivityNotExited)
-    .sort(sortActivitiesByEventDate)[0];
+    .sort(compareActivitiesByEventDate)[0];
 }
 
 export default function findTargetActivityIndexes(
@@ -33,7 +33,7 @@ export default function findTargetActivityIndexes(
         break;
       }
 
-      const sorted = activities.slice().sort(sortActivitiesByEventDate);
+      const sorted = activities.slice().sort(compareActivitiesByEventDate);
 
       const transitionState: ActivityTransitionState =
         event.skipEnterActiveState || isTransitionDone

--- a/core/src/activity-utils/findTargetActivityIndexes.ts
+++ b/core/src/activity-utils/findTargetActivityIndexes.ts
@@ -5,7 +5,6 @@ import { findIndices, last } from "../utils";
 function isActivityNotExited(activity: Activity) {
   return !activity.exitedBy;
 }
-
 function compareActivitiesByEventDate(a1: Activity, a2: Activity) {
   return a2.enteredBy.eventDate - a1.enteredBy.eventDate;
 }


### PR DESCRIPTION
공통적으로 사용하는 모듈들을 정의하고 재사용하는데 성공했어요.

PR 이유
- 같은 형태의 코드들의 반복이 있어 하나로 관리할 수 있을 것 같았어요.
- 하나로 관리를 하게되면 나중에 stackflow 유지보수 할 때 편리해질 것으로 예상됩니다!