### PR TITLE
feat(plugin-basic-ui): add `appBar.overflow` option

### DIFF
--- a/extensions/plugin-basic-ui/src/components/AppBar.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppBar.css.ts
@@ -17,8 +17,11 @@ import {
   vars,
 } from "./AppScreen.css";
 
-const minHeight = style({
+const appBarMinHeight = style({
   minHeight: globalVars.appBar.minHeight,
+});
+const appBarOverflow = style({
+  overflow: globalVars.appBar.overflow,
 });
 
 export const appBar = recipe({
@@ -26,8 +29,8 @@ export const appBar = recipe({
     f.posAbs,
     f.fullWidth,
     f.contentBox,
-    f.overflowHidden,
     background,
+    appBarOverflow,
     {
       backgroundColor: globalVars.appBar.backgroundColor,
       zIndex: vars.zIndexes.appBar,
@@ -109,7 +112,7 @@ export const safeArea = style({
 
 export const container = style([
   f.flexAlignEnd,
-  f.overflowHidden,
+  appBarOverflow,
   {
     height: globalVars.appBar.height,
     transition: `height ${globalVars.appBar.heightTransitionDuration}`,
@@ -119,7 +122,7 @@ export const container = style([
 export const left = style([
   f.flexAlignCenter,
   f.fullHeight,
-  minHeight,
+  appBarMinHeight,
   {
     padding: "0 0.5rem",
     ":empty": {
@@ -147,7 +150,7 @@ export const backButton = style([
 
 export const closeButton = style([backButton]);
 
-export const center = style([f.flexAlignCenter, f.flex1, minHeight]);
+export const center = style([f.flexAlignCenter, f.flex1, appBarMinHeight]);
 
 export const centerMain = recipe({
   base: {
@@ -240,7 +243,7 @@ export const right = style([
   f.flexAlignCenter,
   f.fullHeight,
   f.posRel,
-  minHeight,
+  appBarMinHeight,
   {
     padding: "0 0.5rem",
     marginLeft: "auto",

--- a/extensions/plugin-basic-ui/src/components/AppBar.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppBar.tsx
@@ -18,6 +18,7 @@ type AppBarProps = Partial<
     | "borderSize"
     | "height"
     | "heightTransitionDuration"
+    | "overflow"
     | "iconColor"
     | "textColor"
     | "backgroundColor"
@@ -65,6 +66,8 @@ const AppBar = React.forwardRef<HTMLDivElement, AppBarProps>(
       borderColor,
       borderSize,
       height,
+      heightTransitionDuration,
+      overflow,
       backgroundColor,
       onTopClick,
     },
@@ -266,6 +269,9 @@ const AppBar = React.forwardRef<HTMLDivElement, AppBarProps>(
             [globalVars.appBar.borderColor]: borderColor,
             [globalVars.appBar.borderSize]: borderSize,
             [globalVars.appBar.height]: height,
+            [globalVars.appBar.heightTransitionDuration]:
+              heightTransitionDuration,
+            [globalVars.appBar.overflow]: overflow,
             [globalVars.appBar.backgroundColor]:
               backgroundColor || globalVars.backgroundColor,
             [appScreenCss.vars.appBar.center.mainWidth]: `${maxWidth}px`,

--- a/extensions/plugin-basic-ui/src/theme.css.ts
+++ b/extensions/plugin-basic-ui/src/theme.css.ts
@@ -18,6 +18,7 @@ export const globalVars = createGlobalThemeContract(
       iconColor: "app-bar-icon-color",
       textColor: "app-bar-text-color",
       backgroundColor: "app-bar-background-color",
+      overflow: "app-bar-overflow",
     },
     bottomSheet: {
       borderRadius: "bottom-sheet-border-radius",
@@ -44,6 +45,7 @@ const defaultVars = {
     iconColor: "#212124",
     textColor: "#212124",
     backgroundColor: "#fff",
+    overflow: "hidden",
   },
   bottomSheet: {
     borderRadius: "1rem",


### PR DESCRIPTION
- 앱바에서 툴팁을 띄우는 경우, 앱바 바깥의 UI가 가려지는 이슈
- 개발자가 CSS `overflow` 속성을 제어할 수 있도록 인터페이스 오픈