### PR TITLE
refactor(plugin-history-sync): eliminate-unnecessary-operations

### DIFF
--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -419,11 +419,9 @@ export function historySyncPlugin<
 
         popFlag += popCount;
 
-        do {
-          for (let i = 0; i < popCount; i += 1) {
-            history.back();
-          }
-        } while (!safeParseState(getCurrentState({ history })));
+        if (popCount > 0) {
+          history.go(-popCount);
+        }
       },
     };
   };


### PR DESCRIPTION
기존 stackflow는 현재 액티비티에 해당하는 스텝 수만큼 브라우저의 뒤로 가기 버튼이나 `history.back()` 함수를 호출하여, 이전 상태로 돌아갔어요.

`history.back()` 함수를 모든 스텝만큼 호출하는 비용은 없어도 된다고 생각했고 해당 PR은 이것에 대해 해결하려고 했어요.

`history.go()` 사용을 통해 반복문을 제거하였어요.