### PR TITLE
fix(plugin-history-sync): make history actions work sequentially

### DIFF
--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -12,6 +12,7 @@ import {
 import { last } from "./last";
 import { makeTemplate } from "./makeTemplate";
 import { normalizeRoute } from "./normalizeRoute";
+import { makeQueue } from "./queue";
 import { RoutesProvider } from "./RoutesContext";
 
 const SECOND = 1000;
@@ -46,29 +47,7 @@ export function historySyncPlugin<
     let pushFlag = 0;
     let popFlag = 0;
 
-    let pending = false;
-
-    const queue = (cb: () => void) => {
-      const start = () => {
-        pending = true;
-
-        const clean = history.listen(() => {
-          clean();
-          pending = false;
-        });
-
-        cb();
-      };
-
-      if (pending) {
-        const clean = history.listen(() => {
-          clean();
-          start();
-        });
-      } else {
-        start();
-      }
-    };
+    const queue = makeQueue(history);
 
     return {
       key: "plugin-history-sync",

--- a/extensions/plugin-history-sync/src/queue.ts
+++ b/extensions/plugin-history-sync/src/queue.ts
@@ -1,0 +1,31 @@
+import type { History } from "history";
+
+/**
+ * This function is required to avoid any race conditions caused by asynchronous history updates.
+ */
+export const makeQueue = (history: History) => {
+  let pending = false;
+
+  const queue = (cb: () => void) => {
+    const start = () => {
+      pending = true;
+      const clean = history.listen(() => {
+        clean();
+        pending = false;
+      });
+
+      cb();
+    };
+
+    if (pending) {
+      const clean = history.listen(() => {
+        clean();
+        start();
+      });
+    } else {
+      start();
+    }
+  };
+
+  return queue;
+};


### PR DESCRIPTION
Delays the next history changing event until the URL sync caused by the previous history event is done.