### PR TITLE
docs: set transition duration

### DIFF
--- a/docs/pages/advanced/migrate-from-karrotframe.mdx
+++ b/docs/pages/advanced/migrate-from-karrotframe.mdx
@@ -54,6 +54,7 @@ const App: React.FC = () => {
  * to-be:
  */
 const { Stack } = stackflow({
+  transitionDuration: 350,
   activities: {
     MyPage,
     NotFoundPage,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/77133565/227003211-230b60a2-49b2-41d1-869e-e655120799c7.png)

[문서](https://stackflow.so/advanced/migrate-from-karrotframe#1-stack%EC%9C%BC%EB%A1%9C-%EC%98%AE%EA%B2%A8%EA%B0%80%EA%B8%B0)를 통해 Karrotframe에서 이사를 시도하다 transitionDuration가 누락된 것을 발견하여 문서에 추가했습니다
