### PR TITLE
fix(plugin-ga4): set document.title to ga4 page_title

### DIFF
--- a/extensions/plugin-google-analytics-4/src/googleAnalyticsPlugin.tsx
+++ b/extensions/plugin-google-analytics-4/src/googleAnalyticsPlugin.tsx
@@ -54,7 +54,7 @@ export function googleAnalyticsPlugin<
         hitType: "pageview",
         path: window.location.pathname,
         location: window.location.pathname,
-        title: useTitle ? window.location.pathname : activityName,
+        title: useTitle ? document.title : activityName,
         page_referrer: document.referrer,
       });
     },
@@ -68,7 +68,7 @@ export function googleAnalyticsPlugin<
         hitType: "pageview",
         path: window.location.pathname,
         location: window.location.pathname,
-        title: useTitle ? window.location.pathname : activityName,
+        title: useTitle ? document.title : activityName,
         page_referrer: document.referrer,
       });
     },
@@ -82,7 +82,7 @@ export function googleAnalyticsPlugin<
         hitType: "pageview",
         path: window.location.pathname,
         location: window.location.pathname,
-        title: useTitle ? window.location.pathname : activityName,
+        title: useTitle ? document.title : activityName,
         page_referrer: document.referrer,
       });
     },


### PR DESCRIPTION
- GA4로 전환하며 해당 플러그인을 사용하려 하는데, 예상치 못한 동작이 있어서 수정했어요.
- stackflow 문서와 [GA4 기본 동작](https://support.google.com/analytics/answer/12926732?hl=en)과 다르게 title(page_title) 을 `location.pathname`으로 적용하고 있어서 수정했어요.
- 대신 GA4 기본 동작인 `document.title` 을 사용하도록 변경해요. 