### PR TITLE
fix(plugin-history-sync): Implement replacePopCount variable for stepPush when activity is replaced

### DIFF
--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -15,7 +15,7 @@ const SECOND = 1000;
 const MINUTE = 60 * SECOND;
 
 // 2프레임 + 1프레임
-const ENOUGH_DELAY_TIME = 32+16;
+const ENOUGH_DELAY_TIME = 32 + 16;
 
 let dt = 0;
 
@@ -739,7 +739,7 @@ describe("historySyncPlugin", () => {
 
     expect(path(history.location)).toEqual("/home/");
     expect(activeActivity(actions.getStack())?.name).toEqual("Home");
-  })
+  });
 
   test("historySyncPlugin - push 후 stepPush 를 반복한 뒤, replace 를 한 뒤 stepPush 를 반복하고 pop 을 진행해도 첫번째 stack 을 가리킵니다.", async () => {
     actions.push({
@@ -809,7 +809,7 @@ describe("historySyncPlugin", () => {
 
     expect(path(history.location)).toEqual("/home/");
     expect(activeActivity(actions.getStack())?.name).toEqual("Home");
-  })
+  });
 
   test("historySyncPlugin - push 후 stepPush 를 반복한 뒤, replace 를 수행하고 stepPush 를 반복하고 replace를 수행하고 pop을 진행해도 첫번째 stack을 가리킵니다.(for Hugh)", async () => {
     actions.push({
@@ -887,7 +887,7 @@ describe("historySyncPlugin", () => {
 
     expect(path(history.location)).toEqual("/home/");
     expect(activeActivity(actions.getStack())?.name).toEqual("Home");
-  })
+  });
 
   test("historySyncPlugin - push 후 stepPush 를 반복한 뒤, push 를 수행하고 stepPush 를 반복한 뒤 pop 을 수행, 그 후 replace 를 수행하고 pop을 진행해도 첫번째 stack을 가리킵니다.", async () => {
     actions.push({
@@ -963,7 +963,7 @@ describe("historySyncPlugin", () => {
 
     expect(path(history.location)).toEqual("/home/");
     expect(activeActivity(actions.getStack())?.name).toEqual("Home");
-  })
+  });
 
   test("historySyncPlugin - 2회 반복:push 후 stepPush 를 반복한 뒤, push 를 수행하고 stepPush 를 반복한 뒤 pop 을 수행, 그 후 replace 를 수행하고 pop을 진행해도 첫번째 stack을 가리킵니다.", async () => {
     actions.push({
@@ -1109,5 +1109,5 @@ describe("historySyncPlugin", () => {
 
     expect(path(history.location)).toEqual("/home/");
     expect(activeActivity(actions.getStack())?.name).toEqual("Home");
-  })
+  });
 });

--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -682,6 +682,62 @@ describe("historySyncPlugin", () => {
     expect(activeActivity(actions.getStack())?.name).toEqual("Home");
   });
 
+  test("historySyncPlugin - push 후 *push 를 한 번 더 수행한 뒤*, stepPush 를 반복한 뒤, replace 를 하고 pop 을 수행하면 *두번째 stack* 을 가리킵니다.", async () => {
+    actions.push({
+      activityId: "a2",
+      activityName: "Article",
+      activityParams: {
+        articleId: "1",
+      },
+    });
+    actions.push({
+      activityId: "a3",
+      activityName: "ThirdActivity",
+      activityParams: {
+        thirdId: "234",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s2",
+      stepParams: {
+        thirdId: "2",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s3",
+      stepParams: {
+        thirdId: "3",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s4",
+      stepParams: {
+        thirdId: "4",
+      },
+    });
+
+    actions.replace({
+      activityId: "a4",
+      activityName: "FourthActivity",
+      activityParams: {
+        fourthId: "567",
+      },
+    });
+    await delay(ENOUGH_DELAY_TIME);
+
+    actions.pop();
+
+    // 전환이 끝나기까지 충분한 시간
+    // 코어쪽 추가된 테스트 코드가 Resolve 되면 삭제 가능
+    await delay(32 + 16);
+
+    expect(path(history.location)).toEqual("/articles/1/");
+    expect(activeActivity(actions.getStack())?.name).toEqual("Article");
+  });
+
   test("historySyncPlugin - push 후 stepPush 를 반복한 뒤, push 와 pop 을 1회 수행하고 replace를 수행하고 pop 을 진행하면 첫번째 stack 을 가리킵니다.", async () => {
     actions.push({
       activityId: "a2",

--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -805,7 +805,7 @@ describe("historySyncPlugin", () => {
 
     // 전환이 끝나기까지 충분한 시간
     // 코어쪽 추가된 테스트 코드가 Resolve 되면 삭제 가능
-    await delay(16 * 7);
+    await delay(ENOUGH_DELAY_TIME);
 
     expect(path(history.location)).toEqual("/home/");
     expect(activeActivity(actions.getStack())?.name).toEqual("Home");
@@ -947,12 +947,159 @@ describe("historySyncPlugin", () => {
         thirdId: "4",
       },
     });
+    actions.pop();
 
     actions.replace({
       activityId: "a4",
       activityName: "FourthActivity",
       activityParams: {
         fourthId: "345",
+      },
+    });
+    await delay(ENOUGH_DELAY_TIME);
+    actions.pop();
+
+    await delay(ENOUGH_DELAY_TIME);
+
+    expect(path(history.location)).toEqual("/home/");
+    expect(activeActivity(actions.getStack())?.name).toEqual("Home");
+  })
+
+  test("historySyncPlugin - 2회 반복:push 후 stepPush 를 반복한 뒤, push 를 수행하고 stepPush 를 반복한 뒤 pop 을 수행, 그 후 replace 를 수행하고 pop을 진행해도 첫번째 stack을 가리킵니다.", async () => {
+    actions.push({
+      activityId: "a2",
+      activityName: "Article",
+      activityParams: {
+        articleId: "1",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s2",
+      stepParams: {
+        articleId: "2",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s3",
+      stepParams: {
+        articleId: "3",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s4",
+      stepParams: {
+        articleId: "4",
+      },
+    });
+
+    actions.push({
+      activityId: "a3",
+      activityName: "ThirdActivity",
+      activityParams: {
+        thirdId: "234",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s2",
+      stepParams: {
+        thirdId: "2",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s3",
+      stepParams: {
+        thirdId: "3",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s4",
+      stepParams: {
+        thirdId: "4",
+      },
+    });
+    actions.pop();
+
+    actions.replace({
+      activityId: "a4",
+      activityName: "FourthActivity",
+      activityParams: {
+        fourthId: "345",
+      },
+    });
+    await delay(ENOUGH_DELAY_TIME);
+    actions.pop();
+
+    await delay(ENOUGH_DELAY_TIME);
+    actions.push({
+      activityId: "a5",
+      activityName: "ThirdActivity",
+      activityParams: {
+        thirdId: "1",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s2",
+      stepParams: {
+        thirdId: "2",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s3",
+      stepParams: {
+        thirdId: "3",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s4",
+      stepParams: {
+        thirdId: "4",
+      },
+    });
+
+    actions.push({
+      activityId: "a6",
+      activityName: "FourthActivity",
+      activityParams: {
+        fourthId: "234",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s2",
+      stepParams: {
+        fourthId: "2",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s3",
+      stepParams: {
+        fourthId: "3",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s4",
+      stepParams: {
+        fourthId: "4",
+      },
+    });
+    actions.pop();
+
+    actions.replace({
+      activityId: "a7",
+      activityName: "Article",
+      activityParams: {
+        articleId: "345",
       },
     });
     await delay(ENOUGH_DELAY_TIME);

--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -14,6 +14,9 @@ import { historySyncPlugin } from "./historySyncPlugin";
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
 
+// 2프레임 + 1프레임
+const ENOUGH_DELAY_TIME = 32+16;
+
 let dt = 0;
 
 const enoughPastTime = () => {
@@ -667,7 +670,7 @@ describe("historySyncPlugin", () => {
         thirdId: "234",
       },
     });
-    await delay(100);
+    await delay(ENOUGH_DELAY_TIME);
 
     actions.pop();
 
@@ -726,7 +729,7 @@ describe("historySyncPlugin", () => {
         fourthId: "345",
       },
     });
-    await delay(100);
+    await delay(ENOUGH_DELAY_TIME);
 
     actions.pop();
 
@@ -775,8 +778,7 @@ describe("historySyncPlugin", () => {
         fourthId: "345",
       },
     });
-    await delay(100);
-
+    await delay(ENOUGH_DELAY_TIME);
 
     actions.stepPush({
       stepId: "s5",
@@ -846,7 +848,7 @@ describe("historySyncPlugin", () => {
         thirdId: "234",
       },
     });
-    await delay(100);
+    await delay(ENOUGH_DELAY_TIME);
 
     actions.stepPush({
       stepId: "s2",
@@ -876,12 +878,12 @@ describe("historySyncPlugin", () => {
         fourthId: "345",
       },
     });
-    await delay(100);
+    await delay(ENOUGH_DELAY_TIME);
     actions.pop();
 
     // 전환이 끝나기까지 충분한 시간
     // 코어쪽 추가된 테스트 코드가 Resolve 되면 삭제 가능
-    await delay(100);
+    await delay(ENOUGH_DELAY_TIME);
 
     expect(path(history.location)).toEqual("/home/");
     expect(activeActivity(actions.getStack())?.name).toEqual("Home");
@@ -953,10 +955,10 @@ describe("historySyncPlugin", () => {
         fourthId: "345",
       },
     });
-    await delay(100);
+    await delay(ENOUGH_DELAY_TIME);
     actions.pop();
 
-    await delay(100);
+    await delay(ENOUGH_DELAY_TIME);
 
     expect(path(history.location)).toEqual("/home/");
     expect(activeActivity(actions.getStack())?.name).toEqual("Home");

--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -667,6 +667,7 @@ describe("historySyncPlugin", () => {
         thirdId: "234",
       },
     });
+    await delay(100);
 
     actions.pop();
 
@@ -725,6 +726,7 @@ describe("historySyncPlugin", () => {
         fourthId: "345",
       },
     });
+    await delay(100);
 
     actions.pop();
 
@@ -736,7 +738,156 @@ describe("historySyncPlugin", () => {
     expect(activeActivity(actions.getStack())?.name).toEqual("Home");
   })
 
-  test("historySyncPlugin - push 후 stepPush 를 반복한 뒤, push 와 pop 을 1회 수행하고 replace 를 한 뒤 stepPush 를 반복하고 pop 을 진행해도 첫번째 stack 을 가리킵니다.", async () => {
+  test("historySyncPlugin - push 후 stepPush 를 반복한 뒤, replace 를 한 뒤 stepPush 를 반복하고 pop 을 진행해도 첫번째 stack 을 가리킵니다.", async () => {
+    actions.push({
+      activityId: "a2",
+      activityName: "Article",
+      activityParams: {
+        articleId: "1",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s2",
+      stepParams: {
+        articleId: "2",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s3",
+      stepParams: {
+        articleId: "3",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s4",
+      stepParams: {
+        articleId: "4",
+      },
+    });
+
+    actions.replace({
+      activityId: "a4",
+      activityName: "FourthActivity",
+      activityParams: {
+        fourthId: "345",
+      },
+    });
+    await delay(100);
+
+
+    actions.stepPush({
+      stepId: "s5",
+      stepParams: {
+        fourthId: "5",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s6",
+      stepParams: {
+        fourthId: "6",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s7",
+      stepParams: {
+        fourthId: "7",
+      },
+    });
+
+    actions.pop();
+
+    // 전환이 끝나기까지 충분한 시간
+    // 코어쪽 추가된 테스트 코드가 Resolve 되면 삭제 가능
+    await delay(16 * 7);
+
+    expect(path(history.location)).toEqual("/home/");
+    expect(activeActivity(actions.getStack())?.name).toEqual("Home");
+  })
+
+  test("historySyncPlugin - push 후 stepPush 를 반복한 뒤, replace 를 수행하고 stepPush 를 반복하고 replace를 수행하고 pop을 진행해도 첫번째 stack을 가리킵니다.(for Hugh)", async () => {
+    actions.push({
+      activityId: "a2",
+      activityName: "Article",
+      activityParams: {
+        articleId: "1",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s2",
+      stepParams: {
+        articleId: "2",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s3",
+      stepParams: {
+        articleId: "3",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s4",
+      stepParams: {
+        articleId: "4",
+      },
+    });
+
+    actions.replace({
+      activityId: "a3",
+      activityName: "ThirdActivity",
+      activityParams: {
+        thirdId: "234",
+      },
+    });
+    await delay(100);
+
+    actions.stepPush({
+      stepId: "s2",
+      stepParams: {
+        thirdId: "2",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s3",
+      stepParams: {
+        thirdId: "3",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s4",
+      stepParams: {
+        thirdId: "4",
+      },
+    });
+
+    actions.replace({
+      activityId: "a4",
+      activityName: "FourthActivity",
+      activityParams: {
+        fourthId: "345",
+      },
+    });
+    await delay(100);
+    actions.pop();
+
+    // 전환이 끝나기까지 충분한 시간
+    // 코어쪽 추가된 테스트 코드가 Resolve 되면 삭제 가능
+    await delay(100);
+
+    expect(path(history.location)).toEqual("/home/");
+    expect(activeActivity(actions.getStack())?.name).toEqual("Home");
+  })
+
+  test("historySyncPlugin - push 후 stepPush 를 반복한 뒤, push 를 수행하고 stepPush 를 반복한 뒤 pop 을 수행, 그 후 replace 를 수행하고 pop을 진행해도 첫번째 stack을 가리킵니다.", async () => {
     actions.push({
       activityId: "a2",
       activityName: "Article",
@@ -774,7 +925,26 @@ describe("historySyncPlugin", () => {
       },
     });
 
-    actions.pop();
+    actions.stepPush({
+      stepId: "s2",
+      stepParams: {
+        thirdId: "2",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s3",
+      stepParams: {
+        thirdId: "3",
+      },
+    });
+
+    actions.stepPush({
+      stepId: "s4",
+      stepParams: {
+        thirdId: "4",
+      },
+    });
 
     actions.replace({
       activityId: "a4",
@@ -783,33 +953,10 @@ describe("historySyncPlugin", () => {
         fourthId: "345",
       },
     });
-
-    actions.stepPush({
-      stepId: "s5",
-      stepParams: {
-        fourthId: "5",
-      },
-    });
-
-    actions.stepPush({
-      stepId: "s6",
-      stepParams: {
-        fourthId: "6",
-      },
-    });
-
-    actions.stepPush({
-      stepId: "s7",
-      stepParams: {
-        fourthId: "7",
-      },
-    });
-
+    await delay(100);
     actions.pop();
 
-    // 전환이 끝나기까지 충분한 시간
-    // 코어쪽 추가된 테스트 코드가 Resolve 되면 삭제 가능
-    await delay(16 * 7);
+    await delay(100);
 
     expect(path(history.location)).toEqual("/home/");
     expect(activeActivity(actions.getStack())?.name).toEqual("Home");

--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -407,7 +407,10 @@ export function historySyncPlugin<
           },
         });
       },
-      onBeforeReplace({ actionParams, actions: { overrideActionParams, getStack } }) {
+      onBeforeReplace({
+        actionParams,
+        actions: { overrideActionParams, getStack },
+      }) {
         const template = makeTemplate(
           normalizeRoute(options.routes[actionParams.activityName])[0],
           options.urlPatternOptions,
@@ -424,10 +427,17 @@ export function historySyncPlugin<
 
         const { activities } = getStack();
         const enteredActivities = activities.filter(
-          (currentActivity) => currentActivity.transitionState === "enter-active" || currentActivity.transitionState === "enter-done"
+          (currentActivity) =>
+            currentActivity.transitionState === "enter-active" ||
+            currentActivity.transitionState === "enter-done",
         );
-        const previousActivity = enteredActivities.length > 0 ? enteredActivities[enteredActivities.length - 1] : null;
-        const popCount =  previousActivity?.steps.length ? previousActivity.steps.length : 0;
+        const previousActivity =
+          enteredActivities.length > 0
+            ? enteredActivities[enteredActivities.length - 1]
+            : null;
+        const popCount = previousActivity?.steps.length
+          ? previousActivity.steps.length
+          : 0;
 
         replacePopCount += popCount;
       },
@@ -461,7 +471,7 @@ export function historySyncPlugin<
             : null;
 
         const currentStepsLength = currentActivity?.steps.length ?? 0;
-        const popCount =  replacePopCount + currentStepsLength;
+        const popCount = replacePopCount + currentStepsLength;
         popFlag += popCount;
 
         do {
@@ -471,7 +481,8 @@ export function historySyncPlugin<
 
           if (
             currentActivity?.enteredBy.name === "Replaced" &&
-            previousActivity && replacePopCount > 0
+            previousActivity &&
+            replacePopCount > 0
           ) {
             replacePopCount = 0;
           }

--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -48,6 +48,7 @@ export function historySyncPlugin<
   return () => {
     let pushFlag = 0;
     let popFlag = 0;
+    let replacePopCount = 0;
 
     const queue = makeQueue(history);
 
@@ -406,7 +407,7 @@ export function historySyncPlugin<
           },
         });
       },
-      onBeforeReplace({ actionParams, actions: { overrideActionParams } }) {
+      onBeforeReplace({ actionParams, actions: { overrideActionParams, getStack } }) {
         const template = makeTemplate(
           normalizeRoute(options.routes[actionParams.activityName])[0],
           options.urlPatternOptions,
@@ -420,6 +421,15 @@ export function historySyncPlugin<
             path,
           },
         });
+
+        const { activities } = getStack();
+        const enteredActivities = activities.filter(
+          (currentActivity) => currentActivity.transitionState === "enter-active" || currentActivity.transitionState === "enter-done"
+        );
+        const previousActivity = enteredActivities.length > 0 ? enteredActivities[enteredActivities.length - 1] : null;
+        const popCount =  previousActivity?.steps.length ? previousActivity.steps.length : 0;
+
+        replacePopCount += popCount;
       },
       onBeforeStepPop({ actions: { getStack } }) {
         const { activities } = getStack();
@@ -451,26 +461,19 @@ export function historySyncPlugin<
             : null;
 
         const currentStepsLength = currentActivity?.steps.length ?? 0;
-        let popCount = currentStepsLength;
-
-        if (
-          currentActivity?.enteredBy.name === "Replaced" &&
-          previousActivity
-        ) {
-          const previousStepsLength = previousActivity.steps.length;
-
-          // replace action 을 통해 1회 pop 을 수행한 것이 되기 때문에 popCount 에서 1 을 빼준다.
-          const replacedActivityDepth = 1;
-          // Replaced 이벤트의 경우 'replace 로 대체하는 stack' 의 step 들에 대하여 history.back 를 수행해 history 를 stack 상태와 동기화 시킨다.
-          popCount =
-            currentStepsLength + previousStepsLength - replacedActivityDepth;
-        }
-
+        const popCount =  replacePopCount + currentStepsLength;
         popFlag += popCount;
 
         do {
           for (let i = 0; i < popCount; i += 1) {
             queue(history.back);
+          }
+
+          if (
+            currentActivity?.enteredBy.name === "Replaced" &&
+            previousActivity && replacePopCount > 0
+          ) {
+            replacePopCount = 0;
           }
         } while (!safeParseState(getCurrentState({ history })));
       },

--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -471,7 +471,19 @@ export function historySyncPlugin<
             : null;
 
         const currentStepsLength = currentActivity?.steps.length ?? 0;
-        const popCount = replacePopCount + currentStepsLength;
+
+        let popCount = currentStepsLength;
+
+        if (
+          currentActivity?.enteredBy.name === "Replaced" &&
+          previousActivity
+        ) {
+          // replace 이후에 stepPush 만 진행하고 pop 을 수행하는 경우
+          const shouldPopForCurrentStepPush = currentStepsLength > 1;
+          popCount = shouldPopForCurrentStepPush
+            ? replacePopCount + currentStepsLength
+            : replacePopCount;
+        }
         popFlag += popCount;
 
         do {


### PR DESCRIPTION
- Add delay time for each test to ensure `exit-done` activity after replaced event
- Add some test to check required specs

- 잘못된 테스트들에 delay 를 추가해서 replace 이벤트 이후 exit-done 이 되어야 하는 activity 들이 exit-done 이 아닌 것을 보정했어요.
- 여전히 문제가 발생하고 있는 시나리오를 테스트로 추가했어요. 또 stepsPush 를 pop 했을 때 정상적으로 pop 해서 stepsPush 를 더 이상 pop 에서 고려하지 않아도 되는 상황을 테스트로 추가했어요.