### PR TITLE
fix: useStyleEffectSwipeBack bug

### DIFF
--- a/extensions/plugin-basic-ui/src/hooks/useStyleEffectSwipeBack.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useStyleEffectSwipeBack.ts
@@ -206,7 +206,7 @@ export function useStyleEffectSwipeBack({
           };
 
           const onTouchMove = (e: TouchEvent) => {
-            if (!x0) {
+            if (x0 == null) {
               resetState();
               return;
             }
@@ -217,7 +217,7 @@ export function useStyleEffectSwipeBack({
           };
 
           const onTouchEnd = () => {
-            if (!x0 || !t0 || !x) {
+            if (x0 == null || !t0 || !x) {
               resetState();
               return;
             }


### PR DESCRIPTION
* `useStyleEffectSwipeBack` hook으로 swipe back 기능을 사용할 때 스마트폰 디바이스의 맨왼쪽부터 swipe를 하면 swipe back이 동작하지 않는 현상을 수정합니다.
* 어떤 현상인지 설명하는 간략한 영상을 찍어봤습니다.
  * https://github.com/daangn/stackflow/assets/538584/26c94ce9-67d7-4a53-96ec-c5429557b4a1
* `touchstart`와 `touchend` 이벤트에서 swipe 시작위치인 `x0`를 체크하는 부분을 수정헀습니다. `x0`값이 `0`이어도 swipe back이 동작하도록요.