### PR TITLE
fix(core): prevent replaced root activity from pop event

### DIFF
--- a/core/src/activity-utils/findTargetActivityIndexes.ts
+++ b/core/src/activity-utils/findTargetActivityIndexes.ts
@@ -58,7 +58,11 @@ export default function findTargetActivityIndexes(
       break;
     }
     case "Popped": {
-      const latestActivity = findLatestActiveActivity(activities.slice(1));
+      const sorted = activities
+        .filter(isActivityNotExited)
+        .sort(compareActivitiesByEventDate);
+
+      const latestActivity = sorted.slice(0, sorted.length - 1)[0];
 
       if (latestActivity) {
         targetActivities.push(activities.indexOf(latestActivity));

--- a/core/src/aggregate.spec.ts
+++ b/core/src/aggregate.spec.ts
@@ -1066,6 +1066,114 @@ test("aggregate - 가장 바닥에 있는 Activity는 Pop 되지 않습니다", 
     transitionDuration: 300,
     globalTransitionState: "idle",
   });
+})
+
+test("aggregate - push 후 replace 한 뒤 stepPush를 하고 pop 을 수행하면 pop을 무효화한다.", () => {
+  let pushedEvent1: PushedEvent;
+  let replacedEvent1: ReplacedEvent;
+  let stepPushedEvent1: StepPushedEvent;
+
+  const initEvents = [
+    initializedEvent({
+      transitionDuration: 300,
+    }),
+    registeredEvent({
+      activityName: "home",
+    }),
+    registeredEvent({
+      activityName: "sample",
+    }),
+    (pushedEvent1 = makeEvent("Pushed", {
+      activityId: "a1",
+      activityName: "home",
+      activityParams: {},
+      eventDate: enoughPastTime(),
+    })),
+  ];
+
+  const output1 = aggregate(
+    [
+      ...initEvents,
+      (replacedEvent1 = makeEvent("Replaced", {
+        activityId: "a2",
+        activityName: "sample",
+        activityParams: {},
+        eventDate: enoughPastTime(),
+      })),
+      (stepPushedEvent1 = makeEvent("StepPushed", {
+        stepId: 's1',
+        stepParams: {
+          foo: 'bar'
+        },
+        eventDate: enoughPastTime(),
+      })),
+      (makeEvent("Popped", {
+        eventDate: enoughPastTime(),
+      }))
+    ],
+    nowTime(),
+  );
+
+  expect(output1).toStrictEqual({
+    activities: [
+     activity({
+        id: "a1",
+        name: "home",
+        transitionState: "exit-done",
+        params: {},
+        steps: [
+          {
+            id: "a1",
+            params: {},
+            enteredBy: pushedEvent1,
+          },
+        ],
+        enteredBy: pushedEvent1,
+        exitedBy: replacedEvent1,
+        isActive: false,
+        isTop: false,
+        isRoot: false,
+        zIndex: -1,
+      }),
+      activity({
+        id: "a2",
+        name: "sample",
+        transitionState: "enter-done",
+        params: {
+          "foo": "bar"
+        },
+        steps: [
+          {
+            id: "a2",
+            params: {},
+            enteredBy: replacedEvent1,
+          },
+          {
+            id: "s1",
+            params: {
+              foo: "bar",
+            },
+            enteredBy: stepPushedEvent1,
+          }
+        ],
+        enteredBy: replacedEvent1,
+        isActive: true,
+        isTop: true,
+        isRoot: true,
+        zIndex: 0,
+      })
+    ],
+    registeredActivities: [
+      {
+        name: "home",
+      },
+      {
+        name: "sample"
+      }
+    ],
+    transitionDuration: 300,
+    globalTransitionState: "idle",
+  });
 });
 
 test("aggregate - transitionDuration 이전에 Pop을 한 경우 exit-active 상태입니다", () => {

--- a/core/src/aggregate.spec.ts
+++ b/core/src/aggregate.spec.ts
@@ -1066,7 +1066,7 @@ test("aggregate - 가장 바닥에 있는 Activity는 Pop 되지 않습니다", 
     transitionDuration: 300,
     globalTransitionState: "idle",
   });
-})
+});
 
 test("aggregate - push 후 replace 한 뒤 stepPush를 하고 pop 을 수행하면 pop을 무효화한다.", () => {
   let pushedEvent1: PushedEvent;
@@ -1101,22 +1101,22 @@ test("aggregate - push 후 replace 한 뒤 stepPush를 하고 pop 을 수행하�
         eventDate: enoughPastTime(),
       })),
       (stepPushedEvent1 = makeEvent("StepPushed", {
-        stepId: 's1',
+        stepId: "s1",
         stepParams: {
-          foo: 'bar'
+          foo: "bar",
         },
         eventDate: enoughPastTime(),
       })),
-      (makeEvent("Popped", {
+      makeEvent("Popped", {
         eventDate: enoughPastTime(),
-      }))
+      }),
     ],
     nowTime(),
   );
 
   expect(output1).toStrictEqual({
     activities: [
-     activity({
+      activity({
         id: "a1",
         name: "home",
         transitionState: "exit-done",
@@ -1140,7 +1140,7 @@ test("aggregate - push 후 replace 한 뒤 stepPush를 하고 pop 을 수행하�
         name: "sample",
         transitionState: "enter-done",
         params: {
-          "foo": "bar"
+          foo: "bar",
         },
         steps: [
           {
@@ -1154,22 +1154,22 @@ test("aggregate - push 후 replace 한 뒤 stepPush를 하고 pop 을 수행하�
               foo: "bar",
             },
             enteredBy: stepPushedEvent1,
-          }
+          },
         ],
         enteredBy: replacedEvent1,
         isActive: true,
         isTop: true,
         isRoot: true,
         zIndex: 0,
-      })
+      }),
     ],
     registeredActivities: [
       {
         name: "home",
       },
       {
-        name: "sample"
-      }
+        name: "sample",
+      },
     ],
     transitionDuration: 300,
     globalTransitionState: "idle",

--- a/core/src/aggregate.spec.ts
+++ b/core/src/aggregate.spec.ts
@@ -1068,10 +1068,9 @@ test("aggregate - 가장 바닥에 있는 Activity는 Pop 되지 않습니다", 
   });
 });
 
-test("aggregate - push 후 replace 한 뒤 stepPush를 하고 pop 을 수행하면 pop을 무효화한다.", () => {
+test("aggregate - push 후 replace 한 뒤 pop 을 수행하면 pop을 무효화한다.", () => {
   let pushedEvent1: PushedEvent;
   let replacedEvent1: ReplacedEvent;
-  let stepPushedEvent1: StepPushedEvent;
 
   const initEvents = [
     initializedEvent({
@@ -1098,13 +1097,6 @@ test("aggregate - push 후 replace 한 뒤 stepPush를 하고 pop 을 수행하�
         activityId: "a2",
         activityName: "sample",
         activityParams: {},
-        eventDate: enoughPastTime(),
-      })),
-      (stepPushedEvent1 = makeEvent("StepPushed", {
-        stepId: "s1",
-        stepParams: {
-          foo: "bar",
-        },
         eventDate: enoughPastTime(),
       })),
       makeEvent("Popped", {
@@ -1139,21 +1131,12 @@ test("aggregate - push 후 replace 한 뒤 stepPush를 하고 pop 을 수행하�
         id: "a2",
         name: "sample",
         transitionState: "enter-done",
-        params: {
-          foo: "bar",
-        },
+        params: {},
         steps: [
           {
             id: "a2",
             params: {},
             enteredBy: replacedEvent1,
-          },
-          {
-            id: "s1",
-            params: {
-              foo: "bar",
-            },
-            enteredBy: stepPushedEvent1,
           },
         ],
         enteredBy: replacedEvent1,


### PR DESCRIPTION
- Add test for issue that pop event is activated although current stack is root stack by replace event.

- replace 이벤트로 인해 root 스택에 있는 경우, pop 이벤트를 수행하면 pop 이 진행되지 않아야 하는데, 이것을 확인하는 테스트를 추가합니다.

- Fix 추가