### PR TITLE
test(stackflow): Add id/time Test Code

### DIFF
--- a/core/src/utils/id.spec.ts
+++ b/core/src/utils/id.spec.ts
@@ -7,20 +7,20 @@ beforeAll(() => {
 const getCalculatedId = (time: number) => (time * 1000).toString(16);
 
 test("id - time() 값을 기반으로 유니크한 아이디 값을 반환한다.", () => {
-  const time1 = new Date("2023-08-06").getTime(); // 1691280000000
-  const time2 = new Date("2023-08-07").getTime(); // 1691366400000
+  const expectedTime1 = new Date("2023-08-06").getTime(); // 1691280000000
+  const expectedTime2 = new Date("2023-08-07").getTime(); // 1691366400000
 
-  jest.setSystemTime(time1);
+  jest.setSystemTime(expectedTime1);
 
-  expect(id()).toBe(getCalculatedId(time1));
-  expect(id()).toBe(getCalculatedId((time1 * 1000 + 1) / 1000));
-  expect(id()).toBe(getCalculatedId((time1 * 1000 + 2) / 1000));
-  expect(id()).toBe(getCalculatedId((time1 * 1000 + 3) / 1000));
+  expect(id()).toBe(getCalculatedId(expectedTime1));
+  expect(id()).toBe(getCalculatedId((expectedTime1 * 1000 + 1) / 1000));
+  expect(id()).toBe(getCalculatedId((expectedTime1 * 1000 + 2) / 1000));
+  expect(id()).toBe(getCalculatedId((expectedTime1 * 1000 + 3) / 1000));
 
-  jest.setSystemTime(time2);
+  jest.setSystemTime(expectedTime2);
 
-  expect(id()).toBe(getCalculatedId(time2));
-  expect(id()).toBe(getCalculatedId((time2 * 1000 + 1) / 1000));
-  expect(id()).toBe(getCalculatedId((time2 * 1000 + 2) / 1000));
-  expect(id()).toBe(getCalculatedId((time2 * 1000 + 3) / 1000));
+  expect(id()).toBe(getCalculatedId(expectedTime2));
+  expect(id()).toBe(getCalculatedId((expectedTime2 * 1000 + 1) / 1000));
+  expect(id()).toBe(getCalculatedId((expectedTime2 * 1000 + 2) / 1000));
+  expect(id()).toBe(getCalculatedId((expectedTime2 * 1000 + 3) / 1000));
 });

--- a/core/src/utils/id.spec.ts
+++ b/core/src/utils/id.spec.ts
@@ -1,0 +1,26 @@
+import { id } from "./id";
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+const getCalculatedId = (time: number) => (time * 1000).toString(16);
+
+test("id - time() 값을 기반으로 유니크한 아이디 값을 반환한다.", () => {
+  const time1 = new Date("2023-08-06").getTime(); // 1691280000000
+  const time2 = new Date("2023-08-07").getTime(); // 1691366400000
+
+  jest.setSystemTime(time1);
+
+  expect(id()).toBe(getCalculatedId(time1));
+  expect(id()).toBe(getCalculatedId((time1 * 1000 + 1) / 1000));
+  expect(id()).toBe(getCalculatedId((time1 * 1000 + 2) / 1000));
+  expect(id()).toBe(getCalculatedId((time1 * 1000 + 3) / 1000));
+
+  jest.setSystemTime(time2);
+
+  expect(id()).toBe(getCalculatedId(time2));
+  expect(id()).toBe(getCalculatedId((time2 * 1000 + 1) / 1000));
+  expect(id()).toBe(getCalculatedId((time2 * 1000 + 2) / 1000));
+  expect(id()).toBe(getCalculatedId((time2 * 1000 + 3) / 1000));
+});

--- a/core/src/utils/id.spec.ts
+++ b/core/src/utils/id.spec.ts
@@ -4,23 +4,11 @@ beforeAll(() => {
   jest.useFakeTimers();
 });
 
-const getCalculatedId = (time: number) => (time * 1000).toString(16);
+test("id - 시간을 기반으로 유니크한 아이디 값을 반환한다.", () => {
+  jest.setSystemTime(new Date("2023-08-07T09:00:00Z"));
 
-test("id - time() 값을 기반으로 유니크한 아이디 값을 반환한다.", () => {
-  const expectedTime1 = new Date("2023-08-06").getTime(); // 1691280000000
-  const expectedTime2 = new Date("2023-08-07").getTime(); // 1691366400000
+  const id1 = id();
+  const id2 = id();
 
-  jest.setSystemTime(expectedTime1);
-
-  expect(id()).toBe(getCalculatedId(expectedTime1));
-  expect(id()).toBe(getCalculatedId((expectedTime1 * 1000 + 1) / 1000));
-  expect(id()).toBe(getCalculatedId((expectedTime1 * 1000 + 2) / 1000));
-  expect(id()).toBe(getCalculatedId((expectedTime1 * 1000 + 3) / 1000));
-
-  jest.setSystemTime(expectedTime2);
-
-  expect(id()).toBe(getCalculatedId(expectedTime2));
-  expect(id()).toBe(getCalculatedId((expectedTime2 * 1000 + 1) / 1000));
-  expect(id()).toBe(getCalculatedId((expectedTime2 * 1000 + 2) / 1000));
-  expect(id()).toBe(getCalculatedId((expectedTime2 * 1000 + 3) / 1000));
+  expect(id1).not.toBe(id2);
 });

--- a/core/src/utils/time.spec.ts
+++ b/core/src/utils/time.spec.ts
@@ -5,20 +5,20 @@ beforeAll(() => {
 });
 
 test("time - 이전 호출과 현재 호출 사이에 시간이 동일한 경우 중복을 방지한다.", () => {
-  const time1 = new Date("2023-08-06").getTime(); // 1691280000000
-  const time2 = new Date("2023-08-07").getTime(); // 1691366400000
+  const expectedTime1 = new Date("2023-08-06").getTime(); // 1691280000000
+  const expectedTime2 = new Date("2023-08-07").getTime(); // 1691366400000
 
-  jest.setSystemTime(time1);
+  jest.setSystemTime(expectedTime1);
 
-  expect(time()).toBe(time1);
-  expect(time()).toBe((time1 * 1000 + 1) / 1000);
-  expect(time()).toBe((time1 * 1000 + 2) / 1000);
-  expect(time()).toBe((time1 * 1000 + 3) / 1000);
+  expect(time()).toBe(expectedTime1);
+  expect(time()).toBe((expectedTime1 * 1000 + 1) / 1000);
+  expect(time()).toBe((expectedTime1 * 1000 + 2) / 1000);
+  expect(time()).toBe((expectedTime1 * 1000 + 3) / 1000);
 
-  jest.setSystemTime(time2);
+  jest.setSystemTime(expectedTime2);
 
-  expect(time()).toBe(time2);
-  expect(time()).toBe((time2 * 1000 + 1) / 1000);
-  expect(time()).toBe((time2 * 1000 + 2) / 1000);
-  expect(time()).toBe((time2 * 1000 + 3) / 1000);
+  expect(time()).toBe(expectedTime2);
+  expect(time()).toBe((expectedTime2 * 1000 + 1) / 1000);
+  expect(time()).toBe((expectedTime2 * 1000 + 2) / 1000);
+  expect(time()).toBe((expectedTime2 * 1000 + 3) / 1000);
 });

--- a/core/src/utils/time.spec.ts
+++ b/core/src/utils/time.spec.ts
@@ -4,21 +4,11 @@ beforeAll(() => {
   jest.useFakeTimers();
 });
 
-test("time - 기본적으로 getTime() 값을 반환하며, 이전 호출과 현재 호출 사이에 시간이 동일한 경우 중복을 방지한다.", () => {
-  const expectedTime1 = new Date("2023-08-06").getTime(); // 1691280000000
-  const expectedTime2 = new Date("2023-08-07").getTime(); // 1691366400000
+test("time - 동일한 시간에 여러번 호출될 경우 중복을 방지한다.", () => {
+  jest.setSystemTime(new Date("2023-08-07T09:00:00Z"));
 
-  jest.setSystemTime(expectedTime1);
+  const time1 = time();
+  const time2 = time();
 
-  expect(time()).toBe(expectedTime1);
-  expect(time()).toBe((expectedTime1 * 1000 + 1) / 1000);
-  expect(time()).toBe((expectedTime1 * 1000 + 2) / 1000);
-  expect(time()).toBe((expectedTime1 * 1000 + 3) / 1000);
-
-  jest.setSystemTime(expectedTime2);
-
-  expect(time()).toBe(expectedTime2);
-  expect(time()).toBe((expectedTime2 * 1000 + 1) / 1000);
-  expect(time()).toBe((expectedTime2 * 1000 + 2) / 1000);
-  expect(time()).toBe((expectedTime2 * 1000 + 3) / 1000);
+  expect(time1).not.toBe(time2);
 });

--- a/core/src/utils/time.spec.ts
+++ b/core/src/utils/time.spec.ts
@@ -1,0 +1,24 @@
+import { time } from "./time";
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+test("time - 이전 호출과 현재 호출 사이에 시간이 동일한 경우 시간의 중복을 방지한다.", () => {
+  const time1 = new Date("2023-08-06").getTime(); // 1691280000000
+  const time2 = new Date("2023-08-07").getTime(); // 1691366400000
+
+  jest.setSystemTime(time1);
+
+  expect(time()).toBe(time1);
+  expect(time()).toBe((time1 * 1000 + 1) / 1000);
+  expect(time()).toBe((time1 * 1000 + 2) / 1000);
+  expect(time()).toBe((time1 * 1000 + 3) / 1000);
+
+  jest.setSystemTime(time2);
+
+  expect(time()).toBe(time2);
+  expect(time()).toBe((time2 * 1000 + 1) / 1000);
+  expect(time()).toBe((time2 * 1000 + 2) / 1000);
+  expect(time()).toBe((time2 * 1000 + 3) / 1000);
+});

--- a/core/src/utils/time.spec.ts
+++ b/core/src/utils/time.spec.ts
@@ -4,7 +4,7 @@ beforeAll(() => {
   jest.useFakeTimers();
 });
 
-test("time - 이전 호출과 현재 호출 사이에 시간이 동일한 경우 중복을 방지한다.", () => {
+test("time - 기본적으로 getTime() 값을 반환하며, 이전 호출과 현재 호출 사이에 시간이 동일한 경우 중복을 방지한다.", () => {
   const expectedTime1 = new Date("2023-08-06").getTime(); // 1691280000000
   const expectedTime2 = new Date("2023-08-07").getTime(); // 1691366400000
 

--- a/core/src/utils/time.spec.ts
+++ b/core/src/utils/time.spec.ts
@@ -4,7 +4,7 @@ beforeAll(() => {
   jest.useFakeTimers();
 });
 
-test("time - 이전 호출과 현재 호출 사이에 시간이 동일한 경우 시간의 중복을 방지한다.", () => {
+test("time - 이전 호출과 현재 호출 사이에 시간이 동일한 경우 중복을 방지한다.", () => {
   const time1 = new Date("2023-08-06").getTime(); // 1691280000000
   const time2 = new Date("2023-08-07").getTime(); // 1691366400000
 


### PR DESCRIPTION
안녕하세요 👋
core/utils 내부의 `id()`와 `time()` 함수에 대한 테스트 코드를 추가하는 작업을 진행해봤습니다.
적절한 Pull Request인지 검토부탁드립니다 🙏

## 요약
jest에서 제공해주는 `useFakeTimer()`를 통해 파일 내의 테스트에 가짜 타이머를 적용 후, `setSystemTime()`을 통해 현재 시스템 시간을 설정해 `time()` 함수와 이에 의존하는 `id()` 함수의 테스트 코드를 작성하였습니다.

## 테스트 결과
![스크린샷 2023-08-06 오전 1 56 42](https://github.com/daangn/stackflow/assets/64779472/d06b5159-9842-4d47-9327-13d68a09769e)

## 참고
[jest - useFakeTimers](https://jestjs.io/docs/jest-object#jestusefaketimersfaketimersconfig)
[jest - setSystemTime](https://jestjs.io/docs/jest-object#jestsetsystemtimenow-number--date)
