### PR TITLE
feat(plugin-basic-ui): `ANDROID_ONLY_activityEnterStyle`

### DIFF
--- a/extensions/plugin-basic-ui/src/components/AppBar.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppBar.css.ts
@@ -76,8 +76,8 @@ export const appBar = recipe({
         boxShadow: `inset 0px calc(-1 * ${globalVars.appBar.borderSize}) 0 ${globalVars.appBar.borderColor}`,
       },
     },
-    presentModalFullScreen: {
-      true: {
+    modalPresentationStyle: {
+      fullScreen: {
         selectors: {
           [`${cupertino} &`]: {
             transform: "translate3d(0, 100vh, 0)",
@@ -99,6 +99,23 @@ export const appBar = recipe({
               ...appBarCommonTransition,
               transform: vars.transitionDuration,
               opacity: vars.transitionDuration,
+            }),
+          },
+        },
+      },
+    },
+    activityEnterStyle: {
+      slideInLeft: {
+        selectors: {
+          [`${android} &`]: {
+            opacity: 1,
+            transform: "translate3d(0, 0, 0)",
+          },
+          [`${android} ${exitActive} &`]: {
+            transform: "translate3d(100%, 0, 0)",
+            transition: transitions({
+              ...appBarCommonTransition,
+              transform: "0s",
             }),
           },
         },

--- a/extensions/plugin-basic-ui/src/components/AppBar.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppBar.tsx
@@ -52,6 +52,7 @@ type AppBarProps = Partial<
   closeButtonLocation?: "left" | "right";
   border?: boolean;
   modalPresentationStyle?: "fullScreen";
+  activityEnterStyle?: "slideInLeft";
   onTopClick?: (e: React.MouseEvent) => void;
 };
 const AppBar = forwardRef<HTMLDivElement, AppBarProps>(
@@ -65,6 +66,7 @@ const AppBar = forwardRef<HTMLDivElement, AppBarProps>(
       closeButtonLocation = "left",
       border = true,
       modalPresentationStyle,
+      activityEnterStyle,
       iconColor,
       iconColorTransitionDuration,
       textColor,
@@ -95,8 +97,6 @@ const AppBar = forwardRef<HTMLDivElement, AppBarProps>(
       innerRef: centerRef,
       enable: globalOptions.theme === "cupertino",
     });
-
-    const presentModalFullScreen = modalPresentationStyle === "fullScreen";
 
     const onBackClick = (e: React.MouseEvent<HTMLButtonElement>) => {
       if (backButton && "onClick" in backButton && backButton.onClick) {
@@ -168,7 +168,7 @@ const AppBar = forwardRef<HTMLDivElement, AppBarProps>(
               return globalBackButton.renderIcon();
             }
 
-            if (presentModalFullScreen) {
+            if (modalPresentationStyle === "fullScreen") {
               return <IconClose />;
             }
 
@@ -268,7 +268,8 @@ const AppBar = forwardRef<HTMLDivElement, AppBarProps>(
         ref={ref}
         className={css.appBar({
           border,
-          presentModalFullScreen,
+          modalPresentationStyle,
+          activityEnterStyle,
         })}
         style={assignInlineVars(
           compactMap({

--- a/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
@@ -134,11 +134,20 @@ export const paper = recipe({
         },
       ],
     },
-    presentModalFullScreen: {
-      true: {
+    modalPresentationStyle: {
+      fullScreen: {
         selectors: {
           [`${cupertino} &`]: {
             transform: "translate3d(0, 100%, 0)",
+          },
+        },
+      },
+    },
+    activityEnterStyle: {
+      slideInLeft: {
+        selectors: {
+          [`${android} &`]: {
+            transform: "translate3d(50%, 0, 0)",
           },
         },
       },

--- a/extensions/plugin-basic-ui/src/components/AppScreen.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-param-reassign */
-
 import { useActions } from "@stackflow/react";
 import { assignInlineVars } from "@vanilla-extract/dynamic";
 import { createContext, useContext, useMemo, useRef } from "react";

--- a/extensions/plugin-basic-ui/src/hooks/useStyleEffectOffset.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useStyleEffectOffset.ts
@@ -10,10 +10,12 @@ export const OFFSET_PX_CUPERTINO = 80;
 export function useStyleEffectOffset({
   refs,
   theme,
+  activityEnterStyle,
   hasEffect,
 }: {
   refs: Array<React.RefObject<any>>;
   theme: "android" | "cupertino";
+  activityEnterStyle?: "slideInLeft";
   hasEffect?: boolean;
 }) {
   useStyleEffect({
@@ -21,10 +23,25 @@ export function useStyleEffectOffset({
     refs,
     effect: hasEffect
       ? ({ activityTransitionState, refs }) => {
-          const transform =
-            theme === "cupertino"
-              ? `translate3d(-${OFFSET_PX_CUPERTINO / 16}rem, 0, 0)`
-              : `translate3d(0, -${OFFSET_PX_ANDROID / 16}rem, 0)`;
+          let transform: string;
+          let opacity: string;
+
+          switch (theme) {
+            case "cupertino": {
+              transform = `translate3d(-${OFFSET_PX_CUPERTINO / 16}rem, 0, 0)`;
+              opacity = "1";
+              break;
+            }
+            case "android":
+            default: {
+              transform =
+                activityEnterStyle === "slideInLeft"
+                  ? `translate3d(-50%, 0, 0)`
+                  : `translate3d(0, -${OFFSET_PX_ANDROID / 16}rem, 0)`;
+              opacity = activityEnterStyle === "slideInLeft" ? "0" : "1";
+              break;
+            }
+          }
 
           const cleanup = () => {
             requestNextFrame(() => {
@@ -36,6 +53,7 @@ export function useStyleEffectOffset({
                 const $el = ref.current;
 
                 $el.style.transform = "";
+                $el.style.opacity = "";
 
                 listenOnce($el, "transitionend", () => {
                   $el.style.transition = "";
@@ -55,6 +73,7 @@ export function useStyleEffectOffset({
                 ref.current.style.transition =
                   globalVars.computedTransitionDuration;
                 ref.current.style.transform = transform;
+                ref.current.style.opacity = opacity;
               });
 
               switch (activityTransitionState) {

--- a/extensions/plugin-basic-ui/src/hooks/useStyleEffectOffset.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useStyleEffectOffset.ts
@@ -11,7 +11,7 @@ export function useStyleEffectOffset({
   refs,
   theme,
   activityEnterStyle,
-  hasEffect,
+  hasEffect = false,
 }: {
   refs: Array<React.RefObject<any>>;
   theme: "android" | "cupertino";

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -43,6 +43,7 @@ module.exports = {
         disallowTypeAnnotations: false,
       },
     ],
+    camelcase: "off",
   },
   ignorePatterns: ["**/__generated__/**/*", "**/lib/**/*", "**/dist/**/*"],
 };


### PR DESCRIPTION
## Features
- Implement `slideInLeft` transition on `android` theme

https://github.com/daangn/stackflow/assets/20325202/db61bc1e-3ac3-4881-8a18-76412791a67b

- Refactoring

## BREAKING CHANGES
- Rename `<AppScreen />` props `modalPresentationStyle` -> `CUPERTINO_ONLY_modalPresentationStyle`
