### PR TITLE
fix(link): remove `replace` from anchorProps

### DIFF
--- a/extensions/link/src/Link.tsx
+++ b/extensions/link/src/Link.tsx
@@ -90,6 +90,7 @@ export const Link: TypeLink = forwardRef(
       "activityParams",
       "animate",
       "onClick",
+      "replace",
     ]);
 
     const onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {


### PR DESCRIPTION
## 개요
`<Link />` anchorProps에서 `replace`를 제거해요.

## 맥락
- 기존에는 a tag에 `replace=boolean` attribute가 포함되어 브라우저에서 아래와 같은 워닝 메세지가 뜨고 있었어요
```text
Warning: Received `true` for a non-boolean attribute `replace`.

If you want to write it to the DOM, pass a string instead: replace="true" or replace={value.toString()}.
```
- anchorProps에서 `replace` 를 제거해서 a tag에 내려주지 않게 만들었어요.

## 고려한 대안
- replace를 string으로 치환해서 내려주는 방법도 있어요.
- replace는 현재 stackflow 내부 동작에만 관여하는 props라서 제거를 선택했어요.