### PR TITLE
fix(plugin-basic-ui): remove deps array from max width effect

### DIFF
--- a/extensions/plugin-basic-ui/src/hooks/useMaxWidth.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useMaxWidth.ts
@@ -34,7 +34,7 @@ export function useMaxWidth({
     });
 
     return dispose;
-  }, []);
+  });
 
   return {
     maxWidth,


### PR DESCRIPTION
For now, `max-width` of centered component cannot be changed while the size of some components out of that in `AppBar` is changed by re-rendering (e.g. conditional rendering)

This PR fixes the issue by invoking effect regardless of dependencies for the effect.

