### PR TITLE
fix: rollback to `StackflowReactPlugin<T = never>`

### DIFF
--- a/extensions/plugin-google-analytics-4/src/googleAnalyticsPlugin.tsx
+++ b/extensions/plugin-google-analytics-4/src/googleAnalyticsPlugin.tsx
@@ -29,7 +29,7 @@ export function googleAnalyticsPlugin<
   trackingId,
   userInfo,
   useTitle = false,
-}: GoogleAnalyticsPluginOptions): StackflowReactPlugin {
+}: GoogleAnalyticsPluginOptions): StackflowReactPlugin<T> {
   return () => ({
     key: "@daangn/stackflow-google-analytics-plugin",
     onInit() {

--- a/extensions/plugin-google-analytics-4/src/index.ts
+++ b/extensions/plugin-google-analytics-4/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./googleAnalyticsPlugin";
 export { useGoogleAnalyticsContext } from "./contexts";
+export * from "./googleAnalyticsPlugin";

--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -32,7 +32,7 @@ export function historySyncPlugin<
   T extends { [activityName: string]: unknown },
 >(
   options: HistorySyncPluginOptions<Extract<keyof T, string>>,
-): StackflowReactPlugin {
+): StackflowReactPlugin<T> {
   type K = Extract<keyof T, string>;
 
   const history =

--- a/extensions/plugin-preload/src/pluginPreload.tsx
+++ b/extensions/plugin-preload/src/pluginPreload.tsx
@@ -20,7 +20,7 @@ export type PreloadPluginOptions<
 
 export function preloadPlugin<T extends { [activityName: string]: unknown }>(
   options: PreloadPluginOptions<T>,
-): StackflowReactPlugin {
+): StackflowReactPlugin<T> {
   return () => ({
     key: "plugin-preload",
     wrapStack({ stack }) {

--- a/integrations/react/src/StackflowReactPlugin.ts
+++ b/integrations/react/src/StackflowReactPlugin.ts
@@ -1,6 +1,6 @@
 import type { Activity, Stack, StackflowPlugin } from "@stackflow/core";
 
-export type StackflowReactPlugin = () => {
+export type StackflowReactPlugin<T = never> = () => {
   /**
    * Determine how to render by using the stack state
    */

--- a/integrations/react/src/stackflow.tsx
+++ b/integrations/react/src/stackflow.tsx
@@ -30,7 +30,7 @@ function parseActionOptions(options?: { animate?: boolean }) {
   }
 
   const isNullableAnimateOption = options.animate == null;
-  
+
   if (isNullableAnimateOption) {
     return { skipActiveState: false };
   }
@@ -43,7 +43,7 @@ export type StackComponentType = React.FC<{
 }>;
 
 type StackflowPluginsEntry<T extends BaseActivities> =
-  | StackflowReactPlugin
+  | StackflowReactPlugin<T>
   | StackflowPluginsEntry<T>[];
 
 export type StackflowOptions<T extends BaseActivities> = {


### PR DESCRIPTION
## When `StackflowReactPlugin`
If the `activities` type is not received through return generic `T`, the following problem occurs where type inference is not performed properly.
<img width="482" alt="스크린샷 2023-10-17 오후 1 03 58" src="https://github.com/daangn/stackflow/assets/20325202/40242eb0-ace6-4574-9b46-8d128c8cfd3b">

## When `StackflowReactPlugin<T>`
Since the `activities` type is normally received through generic `T`, the type can be inferred normally.
<img width="483" alt="스크린샷 2023-10-17 오후 1 02 44" src="https://github.com/daangn/stackflow/assets/20325202/ce921e40-1527-43bc-b800-d3bbc055d4ad">
