### PR TITLE
feat(plugin-stack-depth-change): invoke callback only when depth level has changed

### DIFF
--- a/.changeset/dull-eyes-love.md
+++ b/.changeset/dull-eyes-love.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-stack-depth-change": minor
+---
+
+feat(plugin-stack-depth-change): invoke callback only when depth level has changed

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,26 @@
+{
+  "mode": "exit",
+  "tag": "canary",
+  "initialVersions": {
+    "@stackflow/core": "1.0.8",
+    "@stackflow/demo": "1.2.17",
+    "@stackflow/docs": "1.2.18",
+    "@stackflow/compat-await-push": "1.1.5",
+    "@stackflow/link": "1.3.14",
+    "@stackflow/plugin-basic-ui": "1.4.1",
+    "@stackflow/plugin-devtools": "0.1.6",
+    "@stackflow/plugin-google-analytics-4": "1.1.7",
+    "@stackflow/plugin-history-sync": "1.3.13",
+    "@stackflow/plugin-map-initial-activity": "1.0.3",
+    "@stackflow/plugin-preload": "1.2.13",
+    "@stackflow/plugin-renderer-basic": "1.1.5",
+    "@stackflow/plugin-renderer-web": "1.1.5",
+    "@stackflow/plugin-stack-depth-change": "1.0.9",
+    "@stackflow/react": "1.1.5",
+    "@stackflow/esbuild-config": "1.0.0",
+    "@stackflow/eslint-config": "1.0.1"
+  },
+  "changesets": [
+    "dull-eyes-love"
+  ]
+}

--- a/demo/CHANGELOG.md
+++ b/demo/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @stackflow/demo
+
+## 1.2.18-canary.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @stackflow/plugin-stack-depth-change@1.1.0-canary.0

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackflow/demo",
-  "version": "1.2.17",
+  "version": "1.2.18-canary.0",
   "private": true,
   "license": "MIT",
   "exports": {
@@ -41,7 +41,7 @@
     "@stackflow/plugin-map-initial-activity": "^1.0.3",
     "@stackflow/plugin-preload": "^1.2.13",
     "@stackflow/plugin-renderer-basic": "^1.1.5",
-    "@stackflow/plugin-stack-depth-change": "^1.0.9",
+    "@stackflow/plugin-stack-depth-change": "^1.1.0-canary.0",
     "@stackflow/react": "^1.1.5",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.20.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @stackflow/docs
+
+## 1.2.19-canary.0
+
+### Patch Changes
+
+- @stackflow/demo@1.2.18-canary.0

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackflow/docs",
-  "version": "1.2.18",
+  "version": "1.2.19-canary.0",
   "private": true,
   "description": "Mobile-first stack navigator framework with Composable Plugin System",
   "license": "MIT",
@@ -12,7 +12,7 @@
   "dependencies": {
     "@mdx-js/react": "^2.1.1",
     "@stackflow/core": "^1.0.8",
-    "@stackflow/demo": "^1.2.17",
+    "@stackflow/demo": "^1.2.18-canary.0",
     "@stackflow/eslint-config": "^1.0.1",
     "@stackflow/plugin-basic-ui": "^1.4.0",
     "@stackflow/plugin-history-sync": "^1.3.13",

--- a/extensions/plugin-stack-depth-change/CHANGELOG.md
+++ b/extensions/plugin-stack-depth-change/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @stackflow/plugin-stack-depth-change
+
+## 1.1.0-canary.0
+
+### Minor Changes
+
+- feat(plugin-stack-depth-change): invoke callback only when depth level has changed

--- a/extensions/plugin-stack-depth-change/package.json
+++ b/extensions/plugin-stack-depth-change/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackflow/plugin-stack-depth-change",
-  "version": "1.0.9",
+  "version": "1.1.0-canary.0",
   "license": "MIT",
   "exports": {
     ".": {

--- a/extensions/plugin-stack-depth-change/src/stackDepthChangePlugin.tsx
+++ b/extensions/plugin-stack-depth-change/src/stackDepthChangePlugin.tsx
@@ -22,14 +22,20 @@ function getActiveActivities(activities: Activity[]) {
 export function stackDepthChangePlugin(
   options: StackDepthChangePluginOptions,
 ): StackflowPlugin {
+  let prevDepth = 0;
+
   return () => ({
     key: "plugin-stack-depth-change",
     onInit({ actions: { getStack } }) {
       const { activities } = getStack();
       const activeActivities = getActiveActivities(activities);
 
+      const depth = activeActivities.length;
+
+      prevDepth = depth;
+
       options.onInit?.({
-        depth: activeActivities.length,
+        depth,
         activeActivities,
         activities,
       });
@@ -38,11 +44,17 @@ export function stackDepthChangePlugin(
       const { activities } = getStack();
       const activeActivities = getActiveActivities(activities);
 
-      options.onDepthChanged?.({
-        depth: activeActivities.length,
-        activeActivities,
-        activities,
-      });
+      const depth = activeActivities.length;
+
+      if (prevDepth !== depth) {
+        prevDepth = depth;
+
+        options.onDepthChanged?.({
+          depth,
+          activeActivities,
+          activities,
+        });
+      }
     },
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,7 +1918,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@stackflow/demo@^1.2.17, @stackflow/demo@workspace:demo":
+"@stackflow/demo@^1.2.18-canary.0, @stackflow/demo@workspace:demo":
   version: 0.0.0-use.local
   resolution: "@stackflow/demo@workspace:demo"
   dependencies:
@@ -1935,7 +1935,7 @@ __metadata:
     "@stackflow/plugin-map-initial-activity": ^1.0.3
     "@stackflow/plugin-preload": ^1.2.13
     "@stackflow/plugin-renderer-basic": ^1.1.5
-    "@stackflow/plugin-stack-depth-change": ^1.0.9
+    "@stackflow/plugin-stack-depth-change": ^1.1.0-canary.0
     "@stackflow/react": ^1.1.5
     "@types/react": ^18.0.10
     "@types/react-dom": ^18.0.5
@@ -1975,7 +1975,7 @@ __metadata:
     "@mdx-js/react": ^2.1.1
     "@seed-design/stylesheet": ^1.0.0-alpha.0
     "@stackflow/core": ^1.0.8
-    "@stackflow/demo": ^1.2.17
+    "@stackflow/demo": ^1.2.18-canary.0
     "@stackflow/eslint-config": ^1.0.1
     "@stackflow/plugin-basic-ui": ^1.4.0
     "@stackflow/plugin-history-sync": ^1.3.13
@@ -2339,7 +2339,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@stackflow/plugin-stack-depth-change@^1.0.9, @stackflow/plugin-stack-depth-change@workspace:extensions/plugin-stack-depth-change":
+"@stackflow/plugin-stack-depth-change@^1.1.0-canary.0, @stackflow/plugin-stack-depth-change@workspace:extensions/plugin-stack-depth-change":
   version: 0.0.0-use.local
   resolution: "@stackflow/plugin-stack-depth-change@workspace:extensions/plugin-stack-depth-change"
   dependencies:


### PR DESCRIPTION
For now, `stackDepthChangePlugin` invokes `onDepthChanged` callback whenever `onChanged` hook is called.

Our organization has decided to invoke that callback only when the depth level has changed by some internal requests.

And also, that's what we expect from the name in the plugin.