### PR TITLE
fix(plugin-history-sync)!: reduce loop count for parsing state

### DIFF
--- a/.changeset/rotten-berries-sort.md
+++ b/.changeset/rotten-berries-sort.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-history-sync": patch
+---
+
+fix(plugin-history-sync)!: reduce loop count for parsing state

--- a/extensions/plugin-history-sync/src/HistoryQueueContext.tsx
+++ b/extensions/plugin-history-sync/src/HistoryQueueContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useMemo } from "react";
 
 export type HistoryQueueContextValue = {
-  requestHistoryTick: (action: () => void, listen?: boolean) => void;
+  requestHistoryTick: (cb: (resolve: () => void) => void) => void;
 };
 
 export const HistoryQueueContext = createContext<HistoryQueueContextValue>({

--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -440,15 +440,23 @@ export function historySyncPlugin<
             : null;
 
         if (previousActivity) {
-          do {
-            for (let i = 0; i < previousActivity.steps.length - 1; i += 1) {
-              // eslint-disable-next-line no-loop-func
-              requestHistoryTick(() => {
+          for (let i = 0; i < previousActivity.steps.length - 1; i += 1) {
+            // eslint-disable-next-line no-loop-func
+            requestHistoryTick((resolve) => {
+              if (!safeParseState(getCurrentState({ history }))) {
                 silentFlag = true;
                 history.back();
-              });
-            }
-          } while (!safeParseState(getCurrentState({ history })));
+              } else {
+                resolve();
+              }
+            });
+
+            // eslint-disable-next-line no-loop-func
+            requestHistoryTick(() => {
+              silentFlag = true;
+              history.back();
+            });
+          }
         }
       },
       onBeforeStepPop({ actions: { getStack } }) {
@@ -475,15 +483,23 @@ export function historySyncPlugin<
 
           const popCount = isRoot ? 0 : steps.length;
 
-          do {
-            for (let i = 0; i < popCount; i += 1) {
-              // eslint-disable-next-line no-loop-func
-              requestHistoryTick(() => {
+          for (let i = 0; i < popCount; i += 1) {
+            // eslint-disable-next-line no-loop-func
+            requestHistoryTick((resolve) => {
+              if (!safeParseState(getCurrentState({ history }))) {
                 silentFlag = true;
                 history.back();
-              });
-            }
-          } while (!safeParseState(getCurrentState({ history })));
+              } else {
+                resolve();
+              }
+            });
+
+            // eslint-disable-next-line no-loop-func
+            requestHistoryTick(() => {
+              silentFlag = true;
+              history.back();
+            });
+          }
         }
       },
     };

--- a/extensions/plugin-history-sync/src/queue.ts
+++ b/extensions/plugin-history-sync/src/queue.ts
@@ -8,24 +8,20 @@ export const makeHistoryTaskQueue = (history: History) => {
   let previousTask = Promise.resolve();
 
   const requestHistoryTick: HistoryQueueContextValue["requestHistoryTick"] = (
-    cb: () => void,
-    listen: boolean = true,
+    cb,
   ) => {
     previousTask = previousTask.then(
       () =>
         new Promise<void>((resolve) => {
-          if (listen) {
-            const clean = history.listen(() => {
-              clean();
-              resolve();
-            });
-          }
-
-          cb();
-
-          if (!listen) {
+          const clean = history.listen(() => {
+            clean();
             resolve();
-          }
+          });
+
+          cb(() => {
+            clean();
+            resolve();
+          });
         }),
     );
   };


### PR DESCRIPTION
- fix(plugin-history-sync)!: reduce loop count for parsing state

**BREAKING CHANGES:**
- Replace `listen` option into `resolve()` parameter for `requestHistoryTick()`
