### PR TITLE
refactor: replace index signature to record

### DIFF
--- a/core/src/Stack.ts
+++ b/core/src/Stack.ts
@@ -14,9 +14,7 @@ export type ActivityTransitionState =
 
 export type ActivityStep = {
   id: string;
-  params: {
-    [key: string]: string | undefined;
-  };
+  params: Record<string, string | undefined>;
   enteredBy: PushedEvent | ReplacedEvent | StepPushedEvent | StepReplacedEvent;
   exitedBy?: ReplacedEvent | PoppedEvent | StepReplacedEvent | StepPoppedEvent;
 };
@@ -25,9 +23,7 @@ export type Activity = {
   id: string;
   name: string;
   transitionState: ActivityTransitionState;
-  params: {
-    [key: string]: string | undefined;
-  };
+  params: Record<string, string | undefined>;
   context?: {};
   enteredBy: PushedEvent | ReplacedEvent;
   exitedBy?: ReplacedEvent | PoppedEvent;

--- a/core/src/event-types/ActivityRegisteredEvent.ts
+++ b/core/src/event-types/ActivityRegisteredEvent.ts
@@ -6,12 +6,7 @@ export type ActivityRegisteredEvent = BaseDomainEvent<
     activityName: string;
     activityParamsSchema?: {
       type: "object";
-      properties: {
-        [key: string]: {
-          type: "string";
-          enum?: string[];
-        };
-      };
+      properties: Record<string, { type: "string"; enum?: string[] }>;
       required: string[];
     };
   }

--- a/core/src/event-types/PushedEvent.ts
+++ b/core/src/event-types/PushedEvent.ts
@@ -5,9 +5,7 @@ export type PushedEvent = BaseDomainEvent<
   {
     activityId: string;
     activityName: string;
-    activityParams: {
-      [key: string]: string | undefined;
-    };
+    activityParams: Record<string, string | undefined>;
     skipEnterActiveState?: boolean;
     activityContext?: {};
   }

--- a/core/src/event-types/ReplacedEvent.ts
+++ b/core/src/event-types/ReplacedEvent.ts
@@ -5,9 +5,7 @@ export type ReplacedEvent = BaseDomainEvent<
   {
     activityId: string;
     activityName: string;
-    activityParams: {
-      [key: string]: string | undefined;
-    };
+    activityParams: Record<string, string | undefined>;
     skipEnterActiveState?: boolean;
     activityContext?: {};
   }

--- a/core/src/event-types/StepPushedEvent.ts
+++ b/core/src/event-types/StepPushedEvent.ts
@@ -4,8 +4,6 @@ export type StepPushedEvent = BaseDomainEvent<
   "StepPushed",
   {
     stepId: string;
-    stepParams: {
-      [key: string]: string | undefined;
-    };
+    stepParams: Record<string, string | undefined>;
   }
 >;

--- a/core/src/event-types/StepReplacedEvent.ts
+++ b/core/src/event-types/StepReplacedEvent.ts
@@ -4,8 +4,6 @@ export type StepReplacedEvent = BaseDomainEvent<
   "StepReplaced",
   {
     stepId: string;
-    stepParams: {
-      [key: string]: string | undefined;
-    };
+    stepParams: Record<string, string | undefined>;
   }
 >;

--- a/extensions/compat-await-push/src/resolveMap.ts
+++ b/extensions/compat-await-push/src/resolveMap.ts
@@ -1,3 +1,1 @@
-export const resolveMap: {
-  [key: string]: (value: unknown) => void;
-} = {};
+export const resolveMap: Record<string, (value: unknown) => void> = {};

--- a/extensions/link/src/Link.tsx
+++ b/extensions/link/src/Link.tsx
@@ -28,7 +28,7 @@ export type LinkProps<K, P> = {
   urlPatternOptions?: UrlPatternOptions;
 } & AnchorProps;
 
-export type TypeLink<T extends { [activityName: string]: unknown } = {}> = <
+export type TypeLink<T extends Record<string, unknown> = {}> = <
   K extends Extract<keyof T, string>,
 >(
   props: LinkProps<K, T[K] extends ActivityComponentType<infer U> ? U : never>,

--- a/extensions/link/src/createLinkComponent.tsx
+++ b/extensions/link/src/createLinkComponent.tsx
@@ -1,9 +1,7 @@
 import type { TypeLink } from "./Link";
 import { Link } from "./Link";
 
-export function createLinkComponent<
-  T extends { [activityName: string]: unknown },
->(): {
+export function createLinkComponent<T extends Record<string, unknown>>(): {
   Link: TypeLink<T>;
 } {
   return {

--- a/extensions/plugin-google-analytics-4/src/googleAnalyticsPlugin.tsx
+++ b/extensions/plugin-google-analytics-4/src/googleAnalyticsPlugin.tsx
@@ -23,9 +23,7 @@ export type GoogleAnalyticsPluginOptions = {
   };
 };
 
-export function googleAnalyticsPlugin<
-  T extends { [activityName: string]: unknown },
->({
+export function googleAnalyticsPlugin<T extends Record<string, unknown>>({
   trackingId,
   userInfo,
   useTitle = false,

--- a/extensions/plugin-history-sync/src/makeTemplate.ts
+++ b/extensions/plugin-history-sync/src/makeTemplate.ts
@@ -5,7 +5,7 @@ function pathToUrl(path: string) {
 }
 
 function urlSearchParamsToMap(urlSearchParams: URLSearchParams) {
-  const map: { [key: string]: any } = {};
+  const map: Record<string, any> = {};
 
   urlSearchParams.forEach((value, key) => {
     map[key] = value;
@@ -50,7 +50,7 @@ export function makeTemplate(
   const pattern = new UrlPattern(`${templateStr}(/)`, urlPatternOptions);
 
   return {
-    fill(params: { [key: string]: string | undefined }) {
+    fill(params: Record<string, string | undefined>) {
       const pathname = pattern.stringify(params);
       const pathParams = pattern.match(pathname);
 
@@ -79,7 +79,7 @@ export function makeTemplate(
         prependQuestionMarkInSearchParams(searchParams)
       );
     },
-    parse<T extends { [key: string]: string | undefined }>(
+    parse<T extends Record<string, string | undefined>>(
       path: string,
     ): T | null {
       const url = pathToUrl(path);

--- a/extensions/plugin-preload/src/LoadersContext.tsx
+++ b/extensions/plugin-preload/src/LoadersContext.tsx
@@ -2,10 +2,7 @@ import { createContext, useContext } from "react";
 
 import type { Loader } from "./Loader";
 
-export type LoadersMap = {
-  [activityName in string]?: Loader;
-};
-
+export type LoadersMap = Record<string, Loader | undefined>;
 export const LoadersContext = createContext<LoadersMap>({});
 
 interface LoadersProviderProps {

--- a/extensions/plugin-preload/src/createPreloader.ts
+++ b/extensions/plugin-preload/src/createPreloader.ts
@@ -1,9 +1,7 @@
 import type { PreloadFunc } from "./usePreloader";
 import { usePreloader } from "./usePreloader";
 
-export function createPreloader<
-  T extends { [activityName: string]: unknown },
->(): {
+export function createPreloader<T extends Record<string, unknown>>(): {
   usePreloader: () => { preload: PreloadFunc<T> };
 } {
   return {

--- a/extensions/plugin-preload/src/pluginPreload.tsx
+++ b/extensions/plugin-preload/src/pluginPreload.tsx
@@ -6,9 +6,7 @@ import type {
 import type { Loader } from "./Loader";
 import { LoadersProvider } from "./LoadersContext";
 
-export type PreloadPluginOptions<
-  T extends { [activityName: string]: unknown },
-> = {
+export type PreloadPluginOptions<T extends Record<string, unknown>> = {
   loaders: {
     [key in Extract<keyof T, string>]?: T[key] extends ActivityComponentType<
       infer U
@@ -18,7 +16,7 @@ export type PreloadPluginOptions<
   };
 };
 
-export function preloadPlugin<T extends { [activityName: string]: unknown }>(
+export function preloadPlugin<T extends Record<string, unknown>>(
   options: PreloadPluginOptions<T>,
 ): StackflowReactPlugin<T> {
   return () => ({

--- a/integrations/react/src/BaseActivities.ts
+++ b/integrations/react/src/BaseActivities.ts
@@ -2,13 +2,13 @@ import type { ActivityRegisteredEvent } from "@stackflow/core";
 
 import type { ActivityComponentType } from "./activity";
 
-export type BaseActivities = {
-  [activityName: string]:
-    | ActivityComponentType<any>
-    | {
-        component: ActivityComponentType<any>;
-        paramsSchema: NonNullable<
-          ActivityRegisteredEvent["activityParamsSchema"]
-        >;
-      };
-};
+export type BaseActivities = Record<
+  string,
+  | ActivityComponentType<any>
+  | {
+      component: ActivityComponentType<any>;
+      paramsSchema: NonNullable<
+        ActivityRegisteredEvent["activityParamsSchema"]
+      >;
+    }
+>;

--- a/integrations/react/src/MainRenderer.tsx
+++ b/integrations/react/src/MainRenderer.tsx
@@ -7,9 +7,7 @@ import { usePlugins } from "./plugins";
 import type { WithRequired } from "./utils";
 
 interface MainRendererProps {
-  activityComponentMap: {
-    [key: string]: ActivityComponentType;
-  };
+  activityComponentMap: Record<string, ActivityComponentType>;
   initialContext: any;
 }
 const MainRenderer: React.FC<MainRendererProps> = ({

--- a/integrations/react/src/PluginRenderer.tsx
+++ b/integrations/react/src/PluginRenderer.tsx
@@ -7,9 +7,7 @@ import type { StackflowReactPlugin } from "./StackflowReactPlugin";
 import type { WithRequired } from "./utils";
 
 interface PluginRendererProps {
-  activityComponentMap: {
-    [key: string]: ActivityComponentType;
-  };
+  activityComponentMap: Record<string, ActivityComponentType>;
   plugin: WithRequired<ReturnType<StackflowReactPlugin>, "render">;
   initialContext: any;
 }

--- a/integrations/react/src/activity/ActivityComponentType.tsx
+++ b/integrations/react/src/activity/ActivityComponentType.tsx
@@ -1,3 +1,3 @@
 export type ActivityComponentType<
-  T extends { [K in keyof T]: string | undefined } = {},
+  T extends Record<keyof T, string | undefined> = {},
 > = React.ComponentType<{ params: T }>;

--- a/integrations/react/src/activity/useActivityParams.ts
+++ b/integrations/react/src/activity/useActivityParams.ts
@@ -6,7 +6,7 @@ import { ActivityContext } from "./ActivityProvider";
  * Get current activity parameters
  */
 export function useActivityParams<
-  T extends { [key in keyof T]: string | undefined },
+  T extends Record<keyof T, string | undefined>,
 >(): T {
   return useContext(ActivityContext).params as T;
 }

--- a/integrations/react/src/stackflow.tsx
+++ b/integrations/react/src/stackflow.tsx
@@ -128,9 +128,7 @@ export function stackflow<T extends BaseActivities>(
       [key]:
         "component" in Activity ? memo(Activity.component) : memo(Activity),
     }),
-    {} as {
-      [key: string]: ActivityComponentType;
-    },
+    {} as Record<string, ActivityComponentType>,
   );
 
   const enoughPastTime = () =>


### PR DESCRIPTION
## description
By replacing the index signature with Record, the code's readability is enhanced. The Record type provides a more concise and expressive way to define a map or dictionary with string keys, making the type declarations clearer and easier to understand. This change also aligns with TypeScript best practices, promoting a more standardized and maintainable codebase.