### PR TITLE
fix(plugin-basic-ui): theme branching via `:root`'s dataset

### DIFF
--- a/.changeset/weak-jobs-whisper.md
+++ b/.changeset/weak-jobs-whisper.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-basic-ui": minor
+---
+
+theme branching via :root's dataset

--- a/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
@@ -88,6 +88,17 @@ export const cupertino = createTheme(globalVars, {
   ...cupertinoValues,
 });
 
+createGlobalTheme(
+  ":root[data-stackflow-basic-ui-theme=cupertino]",
+  globalVars,
+  cupertinoValues,
+);
+createGlobalTheme(
+  ":root[data-stackflow-basic-ui-theme=android]",
+  globalVars,
+  androidValues,
+);
+
 export const stackWrapper = recipe({
   base: {},
   variants: {

--- a/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
@@ -89,12 +89,12 @@ export const cupertino = createTheme(globalVars, {
 });
 
 createGlobalTheme(
-  ":root[data-stackflow-basic-ui-theme=cupertino]",
+  ":root[data-stackflow-plugin-basic-ui-theme=cupertino]",
   globalVars,
   cupertinoValues,
 );
 createGlobalTheme(
-  ":root[data-stackflow-basic-ui-theme=android]",
+  ":root[data-stackflow-plugin-basic-ui-theme=android]",
   globalVars,
   androidValues,
 );


### PR DESCRIPTION
## Changes
- Theme dependency is currently required for pre-rendering the app shell to HTML.
- Since the theme cannot be imported through JavaScript, it must be adjustable through the `:root` property.
- Therefore, re-add the global theme deleted from https://github.com/daangn/stackflow/pull/370.