### PR TITLE
feat(plugin-basic-ui): export `useStyleEffect()`, `useZIndexBase()`

### DIFF
--- a/.changeset/funny-kings-attack.md
+++ b/.changeset/funny-kings-attack.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-basic-ui": minor
+---
+
+feat(plugin-basic-ui): export `useStyleEffect()`

--- a/.changeset/gentle-kangaroos-study.md
+++ b/.changeset/gentle-kangaroos-study.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-basic-ui": minor
+---
+
+feat(plugin-basic-ui): add `useZIndexBase()`

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -3,11 +3,11 @@
   "tag": "canary",
   "initialVersions": {
     "@stackflow/core": "1.0.10",
-    "@stackflow/demo": "1.2.21",
-    "@stackflow/docs": "1.2.22",
+    "@stackflow/demo": "1.2.22-canary.0",
+    "@stackflow/docs": "1.2.23-canary.0",
     "@stackflow/compat-await-push": "1.1.8",
     "@stackflow/link": "1.4.0",
-    "@stackflow/plugin-basic-ui": "1.6.0",
+    "@stackflow/plugin-basic-ui": "1.7.0-canary.0",
     "@stackflow/plugin-devtools": "0.1.8",
     "@stackflow/plugin-google-analytics-4": "1.1.10",
     "@stackflow/plugin-history-sync": "1.5.0",
@@ -21,6 +21,7 @@
     "@stackflow/eslint-config": "1.0.2"
   },
   "changesets": [
-    "funny-kings-attack"
+    "funny-kings-attack",
+    "gentle-kangaroos-study"
   ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,26 @@
+{
+  "mode": "exit",
+  "tag": "canary",
+  "initialVersions": {
+    "@stackflow/core": "1.0.10",
+    "@stackflow/demo": "1.2.21",
+    "@stackflow/docs": "1.2.22",
+    "@stackflow/compat-await-push": "1.1.8",
+    "@stackflow/link": "1.4.0",
+    "@stackflow/plugin-basic-ui": "1.6.0",
+    "@stackflow/plugin-devtools": "0.1.8",
+    "@stackflow/plugin-google-analytics-4": "1.1.10",
+    "@stackflow/plugin-history-sync": "1.5.0",
+    "@stackflow/plugin-map-initial-activity": "1.0.6",
+    "@stackflow/plugin-preload": "1.3.0",
+    "@stackflow/plugin-renderer-basic": "1.1.8",
+    "@stackflow/plugin-renderer-web": "1.1.8",
+    "@stackflow/plugin-stack-depth-change": "1.1.2",
+    "@stackflow/react": "1.1.9",
+    "@stackflow/esbuild-config": "1.0.1",
+    "@stackflow/eslint-config": "1.0.2"
+  },
+  "changesets": [
+    "funny-kings-attack"
+  ]
+}

--- a/demo/CHANGELOG.md
+++ b/demo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @stackflow/demo
 
+## 1.2.22-canary.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @stackflow/plugin-basic-ui@1.7.0-canary.0
+
 ## 1.2.21
 
 ### Patch Changes

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackflow/demo",
-  "version": "1.2.21",
+  "version": "1.2.22-canary.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @stackflow/docs
 
+## 1.2.23-canary.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @stackflow/plugin-basic-ui@1.7.0-canary.0
+  - @stackflow/demo@1.2.22-canary.0
+
 ## 1.2.22
 
 ### Patch Changes

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackflow/docs",
-  "version": "1.2.22",
+  "version": "1.2.23-canary.0",
   "private": true,
   "description": "Mobile-first stack navigator framework with Composable Plugin System",
   "license": "MIT",
@@ -12,7 +12,7 @@
   "dependencies": {
     "@mdx-js/react": "^3.0.1",
     "@stackflow/core": "^1.0.10",
-    "@stackflow/demo": "^1.2.21",
+    "@stackflow/demo": "^1.2.22-canary.0",
     "@stackflow/plugin-basic-ui": "^1.7.0",
     "@stackflow/plugin-history-sync": "^1.5.0",
     "@stackflow/plugin-renderer-basic": "^1.1.8",

--- a/extensions/plugin-basic-ui/src/components/AppScreen.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.tsx
@@ -12,6 +12,7 @@ import {
   useStyleEffectHide,
   useStyleEffectOffset,
   useStyleEffectSwipeBack,
+  useZIndexBase,
 } from "../hooks";
 import type { PropOf } from "../utils";
 import { compactMap } from "../utils";
@@ -74,7 +75,7 @@ const AppScreen: React.FC<AppScreenProps> = ({
 
   const hasAppBar = !!appBar;
 
-  const zIndexBase = (activity?.zIndex ?? 0) * 5;
+  const zIndexBase = useZIndexBase();
 
   let zIndexDim: number;
   let zIndexPaper: number;

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
@@ -4,7 +4,12 @@ import { useRef } from "react";
 
 import type { GlobalVars } from "../basicUIPlugin.css";
 import { globalVars } from "../basicUIPlugin.css";
-import { useLazy, useNullableActivity, useStyleEffect } from "../hooks";
+import {
+  useLazy,
+  useNullableActivity,
+  useStyleEffect,
+  useZIndexBase,
+} from "../hooks";
 import { compactMap } from "../utils";
 import * as css from "./BottomSheet.css";
 
@@ -63,8 +68,8 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
     e.stopPropagation();
   };
 
-  const zIndexBase = (activity?.zIndex ?? 0) * 5 + 3;
-  const zIndexPaper = (activity?.zIndex ?? 0) * 5 + 4;
+  const zIndexBase = useZIndexBase() + 3;
+  const zIndexPaper = useZIndexBase() + 4;
   const transitionState = activity?.transitionState ?? "enter-done";
 
   return (

--- a/extensions/plugin-basic-ui/src/components/Modal.tsx
+++ b/extensions/plugin-basic-ui/src/components/Modal.tsx
@@ -4,7 +4,12 @@ import { useRef } from "react";
 
 import type { GlobalVars } from "../basicUIPlugin.css";
 import { globalVars } from "../basicUIPlugin.css";
-import { useLazy, useNullableActivity, useStyleEffect } from "../hooks";
+import {
+  useLazy,
+  useNullableActivity,
+  useStyleEffect,
+  useZIndexBase,
+} from "../hooks";
 import { compactMap } from "../utils";
 import * as css from "./Modal.css";
 
@@ -61,8 +66,8 @@ const Modal: React.FC<ModalProps> = ({
     e.stopPropagation();
   };
 
-  const zIndexBase = (activity?.zIndex ?? 0) * 5 + 3;
-  const zIndexPaper = (activity?.zIndex ?? 0) * 5 + 4;
+  const zIndexBase = useZIndexBase() + 3;
+  const zIndexPaper = useZIndexBase() + 4;
   const transitionState = activity?.transitionState ?? "enter-done";
 
   return (

--- a/extensions/plugin-basic-ui/src/hooks/index.ts
+++ b/extensions/plugin-basic-ui/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from "./useStyleEffect";
 export * from "./useStyleEffectHide";
 export * from "./useStyleEffectOffset";
 export * from "./useStyleEffectSwipeBack";
+export * from "./useZIndexBase";

--- a/extensions/plugin-basic-ui/src/hooks/useZIndexBase.ts
+++ b/extensions/plugin-basic-ui/src/hooks/useZIndexBase.ts
@@ -1,0 +1,6 @@
+import { useNullableActivity } from "./useNullableActivity";
+
+export function useZIndexBase() {
+  const activity = useNullableActivity();
+  return (activity?.zIndex ?? 0) * 5;
+}

--- a/extensions/plugin-basic-ui/src/index.ts
+++ b/extensions/plugin-basic-ui/src/index.ts
@@ -15,3 +15,4 @@ export {
 export { vars as bottomSheetVars } from "./components/BottomSheet.css";
 export { default as Modal, ModalProps } from "./components/Modal";
 export { vars as modalVars } from "./components/Modal.css";
+export { useStyleEffect } from "./hooks";

--- a/extensions/plugin-basic-ui/src/index.ts
+++ b/extensions/plugin-basic-ui/src/index.ts
@@ -15,4 +15,4 @@ export {
 export { vars as bottomSheetVars } from "./components/BottomSheet.css";
 export { default as Modal, ModalProps } from "./components/Modal";
 export { vars as modalVars } from "./components/Modal.css";
-export { useStyleEffect } from "./hooks";
+export { useStyleEffect, useZIndexBase } from "./hooks";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,7 +2310,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@stackflow/demo@npm:^1.2.21, @stackflow/demo@workspace:demo":
+"@stackflow/demo@npm:^1.2.22-canary.0, @stackflow/demo@workspace:demo":
   version: 0.0.0-use.local
   resolution: "@stackflow/demo@workspace:demo"
   dependencies:
@@ -2355,7 +2355,7 @@ __metadata:
     "@mdx-js/react": "npm:^3.0.1"
     "@seed-design/stylesheet": "npm:^1.0.4"
     "@stackflow/core": "npm:^1.0.10"
-    "@stackflow/demo": "npm:^1.2.21"
+    "@stackflow/demo": "npm:^1.2.22-canary.0"
     "@stackflow/plugin-basic-ui": "npm:^1.7.0"
     "@stackflow/plugin-history-sync": "npm:^1.5.0"
     "@stackflow/plugin-renderer-basic": "npm:^1.1.8"


### PR DESCRIPTION
Export `useStyleEffect()`, `useZIndexBase()` hooks to extend the basic ui based custom activities for the third parties.