### PR TITLE
feat(plugin-basic-ui): expose `paperRef` and add `!important` on exit transition

### DIFF
--- a/.changeset/shy-doors-switch.md
+++ b/.changeset/shy-doors-switch.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-basic-ui": minor
+---
+
+Expose `paperRef` from `<BottomSheet />` and add `!important` paper exit transition

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.css.ts
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.css.ts
@@ -71,8 +71,8 @@ export const paper = style([
         opacity: 1,
       },
       [`${exitActive} &, ${exitDone} &`]: {
-        transform: "translate3d(0, 100%, 0)",
-        opacity: 0,
+        transform: "translate3d(0, 100%, 0) !important",
+        opacity: "0 !important",
       },
     },
   },

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
@@ -14,6 +14,7 @@ export type BottomSheetProps = Partial<
   Pick<GlobalVars, "backgroundColor" | "dimBackgroundColor">
 > &
   Partial<GlobalVars["bottomSheet"]> & {
+    paperRef?: React.Ref<HTMLDivElement>;
     onOutsideClick?: React.MouseEventHandler;
     children: React.ReactNode;
   };
@@ -21,6 +22,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
   borderRadius = "1rem",
   backgroundColor,
   dimBackgroundColor,
+  paperRef,
   onOutsideClick,
   children,
 }) => {
@@ -28,7 +30,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
   const { pop } = useActions();
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const paperRef = useRef<HTMLDivElement>(null);
+  const dimRef = useRef<HTMLDivElement>(null);
 
   useStyleEffect({
     styleName: "hide",
@@ -36,11 +38,11 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
   });
   useStyleEffect({
     styleName: "offset",
-    refs: [paperRef],
+    refs: [dimRef],
   });
   useStyleEffect({
     styleName: "swipe-back",
-    refs: [paperRef],
+    refs: [dimRef],
   });
 
   const popLock = useRef(false);
@@ -91,8 +93,8 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
       data-stackflow-activity-id={activity?.id}
       data-stackflow-activity-is-active={activity?.isActive}
     >
-      <div className={css.dim} ref={paperRef} onClick={onDimClick}>
-        <div className={css.paper} onClick={onPaperClick}>
+      <div className={css.dim} ref={dimRef} onClick={onDimClick}>
+        <div className={css.paper} ref={paperRef} onClick={onPaperClick}>
           {children}
         </div>
       </div>


### PR DESCRIPTION
- Expose `paperRef` property on `<BottomSheet />` component for access element which rendering paper area.
- Add `!important` on bottom sheet exit transitions. it is useful when users set `transform` property via style manually, and try to exit (or pop) bottom sheet.