### PR TITLE
fix(core, plugin-history-sync): accept only serializable parameters

### DIFF
--- a/.changeset/green-bulldogs-learn.md
+++ b/.changeset/green-bulldogs-learn.md
@@ -1,0 +1,6 @@
+---
+"@stackflow/plugin-history-sync": patch
+"@stackflow/core": patch
+---
+
+accept only serializable parameters when making domain event

--- a/core/src/event-utils/makeEvent.ts
+++ b/core/src/event-utils/makeEvent.ts
@@ -2,6 +2,10 @@ import type { DomainEvent } from "../event-types";
 import type { BaseDomainEvent } from "../event-types/_base";
 import { id, time } from "../utils";
 
+function clone<T extends {}>(input: T): T {
+  return JSON.parse(JSON.stringify(input));
+}
+
 export function makeEvent<T extends DomainEvent["name"]>(
   name: T,
   parameters: Omit<
@@ -13,7 +17,7 @@ export function makeEvent<T extends DomainEvent["name"]>(
   return {
     id: id(),
     eventDate: time(),
-    ...parameters,
+    ...clone(parameters),
     name,
   } as Extract<DomainEvent, { name: T }>;
 }

--- a/extensions/plugin-history-sync/src/historyState.ts
+++ b/extensions/plugin-history-sync/src/historyState.ts
@@ -12,31 +12,16 @@ interface SerializedState extends State {
   _TAG: typeof STATE_TAG;
 }
 
+function clone<T>(input: T): T {
+  return JSON.parse(JSON.stringify(input));
+}
+
 function serializeStep(step: ActivityStep): ActivityStep {
-  return {
-    ...step,
-    enteredBy:
-      "activityContext" in step.enteredBy
-        ? {
-            ...step.enteredBy,
-            activityContext: undefined,
-          }
-        : {
-            ...step.enteredBy,
-          },
-  };
+  return clone(step);
 }
 
 function serializeActivity(activity: Activity): Activity {
-  return {
-    ...activity,
-    context: undefined,
-    enteredBy: {
-      ...activity.enteredBy,
-      activityContext: undefined,
-    },
-    steps: activity.steps.map(serializeStep),
-  };
+  return clone(activity);
 }
 
 function serializeState(state: State): SerializedState {


### PR DESCRIPTION
- I discovered the possibility of passing an object with circular dependency to `activity.context`, so there was logic to delete the `activity.context` to make it serializable before assigning it to `history.state`.
- There was a case where `activity.context` was utilized in user land. In this case, the stability of the `activity.context` field must be guaranteed.
- After thinking about it further, I realized that **the event** itself is **serializable**, so I changed the `makeEvent()` function to check for serializability and deleted the logic to delete the `activity.context`.