### PR TITLE
style(plugin-basic-ui): move top padding to margin

### DIFF
--- a/.changeset/short-jars-retire.md
+++ b/.changeset/short-jars-retire.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-basic-ui": patch
+---
+
+style(plugin-basic-ui): move top padding to margin

--- a/demo/src/activities/Main.css.ts
+++ b/demo/src/activities/Main.css.ts
@@ -33,17 +33,6 @@ export const appBarRight = style([
 export const scrollable = style([
   f.flex1,
   f.overflowScroll,
-  {
-    paddingTop: cssVars.appBar.height,
-    "@supports": {
-      "(padding-top: constant(safe-area-inset-top))": {
-        paddingTop: `calc(${cssVars.appBar.height} + constant(safe-area-inset-top))`,
-      },
-      "(padding-top: env(safe-area-inset-top))": {
-        paddingTop: `calc(${cssVars.appBar.height} + env(safe-area-inset-top))`,
-      },
-    },
-  },
 ]);
 
 export const bottom = style({});

--- a/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
@@ -121,14 +121,15 @@ export const paper = recipe({
       true: [
         f.borderBox,
         {
-          transition: `transform ${vars.transitionDuration}, opacity ${vars.transitionDuration}, padding-top ${globalVars.appBar.heightTransitionDuration}`,
-          paddingTop: globalVars.appBar.height,
+          transition: `transform ${vars.transitionDuration}, opacity ${vars.transitionDuration}, margin-top ${globalVars.appBar.heightTransitionDuration}`,
+          marginTop: globalVars.appBar.height,
+          height: `calc(100% - ${globalVars.appBar.height})`,
           "@supports": {
-            "(padding-top: constant(safe-area-inset-top))": {
-              paddingTop: `calc(${globalVars.appBar.height} + max(${globalVars.appBar.minSafeAreaInsetTop}, constant(safe-area-inset-top)))`,
+            "(margin-top: constant(safe-area-inset-top))": {
+              marginTop: `calc(${globalVars.appBar.height} + max(${globalVars.appBar.minSafeAreaInsetTop}, constant(safe-area-inset-top)))`,
             },
-            "(padding-top: env(safe-area-inset-top))": {
-              paddingTop: `calc(${globalVars.appBar.height} + max(${globalVars.appBar.minSafeAreaInsetTop}, env(safe-area-inset-top)))`,
+            "(margin-top: env(safe-area-inset-top))": {
+              marginTop: `calc(${globalVars.appBar.height} + max(${globalVars.appBar.minSafeAreaInsetTop}, env(safe-area-inset-top)))`,
             },
           },
         },


### PR DESCRIPTION
- Substract the height of `AppBar` from `AppScreen` and apply top margin instead of top padding so that paper could have the visible height itself.