### PR TITLE
fix(plugin-basic-ui): remove `will-change` property

### DIFF
--- a/.changeset/ten-squids-yell.md
+++ b/.changeset/ten-squids-yell.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-basic-ui": patch
+---
+
+fix(plugin-basic-ui): remove `will-change` property

--- a/extensions/plugin-basic-ui/src/components/AppBar.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppBar.css.ts
@@ -38,7 +38,6 @@ export const appBar = recipe({
     {
       backgroundColor: globalVars.appBar.backgroundColor,
       zIndex: vars.zIndexes.appBar,
-      willChange: "transform, opacity",
       transition: transitions(appBarCommonTransition),
       selectors: {
         [`${cupertino} &`]: {

--- a/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
@@ -57,7 +57,6 @@ export const dim = style([
   {
     opacity: 0,
     zIndex: vars.zIndexes.dim,
-    willChange: "opacity",
     selectors: {
       [`${android} &`]: {
         height: "10rem",

--- a/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
@@ -91,7 +91,6 @@ export const paper = recipe({
         display: "none",
       },
       zIndex: vars.zIndexes.paper,
-      willChange: "transform",
       selectors: {
         [`${cupertino} &`]: {
           transform: "translate3d(100%, 0, 0)",

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.css.ts
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.css.ts
@@ -62,7 +62,6 @@ export const paper = style([
     backgroundColor: globalVars.backgroundColor,
     width: "100%",
     borderRadius: `${globalVars.bottomSheet.borderRadius} ${globalVars.bottomSheet.borderRadius} 0 0`,
-    willChange: "transform, opacity",
     transform: "translate3d(0, 100%, 0)",
     opacity: 0,
     selectors: {

--- a/extensions/plugin-basic-ui/src/components/Modal.css.ts
+++ b/extensions/plugin-basic-ui/src/components/Modal.css.ts
@@ -66,7 +66,6 @@ export const paper = style([
     boxShadow:
       "0px 0.625rem 2.375rem rgba(0, 0, 0, 0.15), 0px .5625rem 2.875rem rgba(0, 0, 0, 0.12), 0px .3125rem .9375rem rgba(0, 0, 0, 0.1)",
     borderRadius: globalVars.modal.borderRadius,
-    willChange: "transform, opacity",
     transform: "scale(1.1)",
     opacity: 0,
     selectors: {


### PR DESCRIPTION
Currently, the element that has `will-change` property will generate the containing block for the nested fixed element. [W3C Spec](https://drafts.csswg.org/css-will-change/)

To reduce the confusion of using the `position: fixed` element inside `AppScreen` and the other utility activities, we decided to remove the all `will-change` properties used in them.