### PR TITLE
chore: enable `declarationMap` compiler option

### DIFF
--- a/.changeset/lazy-months-repair.md
+++ b/.changeset/lazy-months-repair.md
@@ -1,0 +1,20 @@
+---
+"@stackflow/core": patch
+"@stackflow/demo": patch
+"@stackflow/docs": patch
+"@stackflow/compat-await-push": patch
+"@stackflow/link": patch
+"@stackflow/plugin-basic-ui": patch
+"@stackflow/plugin-devtools": patch
+"@stackflow/plugin-google-analytics-4": patch
+"@stackflow/plugin-history-sync": patch
+"@stackflow/plugin-map-initial-activity": patch
+"@stackflow/plugin-preload": patch
+"@stackflow/plugin-renderer-basic": patch
+"@stackflow/plugin-renderer-web": patch
+"@stackflow/plugin-stack-depth-change": patch
+"@stackflow/react": patch
+"@stackflow/esbuild-config": patch
+---
+
+chore: include declaration map

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "jsx": "react-jsx",
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
Opt-in `declarationMap` for ease in finding the original source within the monorepo or the external uses.