### PR TITLE
feat(plugin-history-sync): sort routes by computed score

### DIFF
--- a/.changeset/tasty-penguins-grow.md
+++ b/.changeset/tasty-penguins-grow.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-history-sync": minor
+---
+
+feat(plugin-history-sync): sort routes by computed score

--- a/extensions/plugin-history-sync/src/sortActivityRoutes.spec.ts
+++ b/extensions/plugin-history-sync/src/sortActivityRoutes.spec.ts
@@ -35,9 +35,9 @@ test("sortActivityRoutes - *이 들어간 경우 해당 라우트를 맨 뒤로 
   ]);
 
   expect(routes).toStrictEqual([
+    { activityName: "C", path: "/:hello/:world/:foo/:bar" },
     { activityName: "A", path: "/detailed/*" },
     { activityName: "B", path: "/:hello/:world" },
-    { activityName: "C", path: "/:hello/:world/:foo/:bar" },
     { activityName: "A", path: "*" },
   ]);
 });

--- a/extensions/plugin-history-sync/src/sortActivityRoutes.ts
+++ b/extensions/plugin-history-sync/src/sortActivityRoutes.ts
@@ -1,10 +1,37 @@
 import type { ActivityRoute } from "./ActivityRoute";
-import { makeTemplate } from "./makeTemplate";
+
+const paramRe = /^:[\w-]+$/;
+const dynamicSegmentValue = 3;
+const emptySegmentValue = 1;
+const staticSegmentValue = 10;
+const splatPenalty = -2;
+const isSplat = (s: string) => s === "*";
+
+function computeScore(path: string): number {
+  const segments = path.split("/");
+  let initialScore = segments.length;
+  if (segments.some(isSplat)) {
+    initialScore += splatPenalty;
+  }
+
+  return segments
+    .filter((s) => !isSplat(s))
+    .reduce(
+      (score, segment) =>
+        score +
+        (paramRe.test(segment)
+          ? dynamicSegmentValue
+          : segment === ""
+          ? emptySegmentValue
+          : staticSegmentValue),
+      initialScore,
+    );
+}
 
 export function sortActivityRoutes<T>(
   routes: ActivityRoute<T>[],
 ): ActivityRoute<T>[] {
   return [...routes].sort(
-    (a, b) => makeTemplate(a).variableCount - makeTemplate(b).variableCount,
+    (a, b) => computeScore(b.path) - computeScore(a.path),
   );
 }

--- a/extensions/plugin-history-sync/src/sortActivityRoutes.ts
+++ b/extensions/plugin-history-sync/src/sortActivityRoutes.ts
@@ -7,6 +7,9 @@ const staticSegmentValue = 10;
 const splatPenalty = -2;
 const isSplat = (s: string) => s === "*";
 
+/**
+ * https://github.com/remix-run/react-router/blob/0f2b167e9b862d5e6b3425438787c8e7b39197f4/packages/router/utils.ts#L742-L773
+ */
 function computeScore(path: string): number {
   const segments = path.split("/");
   let initialScore = segments.length;


### PR DESCRIPTION
Reference: https://github.com/remix-run/react-router/blob/0f2b167e9b862d5e6b3425438787c8e7b39197f4/packages/router/utils.ts#L742-L773