### PR TITLE
fix(plugin-basic-ui): calculate app screen height correctly with safearea

### DIFF
--- a/.changeset/tough-cycles-reflect.md
+++ b/.changeset/tough-cycles-reflect.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-basic-ui": patch
+---
+
+fix(plugin-basic-ui): calculate app screen height correctly with safearea

--- a/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
@@ -13,6 +13,7 @@ export const vars = createThemeContract({
     appBar: null,
   },
   appBar: {
+    topMargin: null,
     center: {
       mainWidth: null,
     },
@@ -120,14 +121,23 @@ export const paper = recipe({
         f.borderBox,
         {
           transition: `transform ${vars.transitionDuration}, opacity ${vars.transitionDuration}, margin-top ${globalVars.appBar.heightTransitionDuration}`,
-          marginTop: globalVars.appBar.height,
-          height: `calc(100% - ${globalVars.appBar.height})`,
+          marginTop: vars.appBar.topMargin,
+          height: `calc(100% - ${vars.appBar.topMargin})`,
+          vars: {
+            [vars.appBar.topMargin]: globalVars.appBar.height,
+          },
           "@supports": {
             "(margin-top: constant(safe-area-inset-top))": {
-              marginTop: `calc(${globalVars.appBar.height} + max(${globalVars.appBar.minSafeAreaInsetTop}, constant(safe-area-inset-top)))`,
+              vars: {
+                [vars.appBar
+                  .topMargin]: `calc(${globalVars.appBar.height} + max(${globalVars.appBar.minSafeAreaInsetTop}, constant(safe-area-inset-top)))`,
+              },
             },
             "(margin-top: env(safe-area-inset-top))": {
-              marginTop: `calc(${globalVars.appBar.height} + max(${globalVars.appBar.minSafeAreaInsetTop}, env(safe-area-inset-top)))`,
+              vars: {
+                [vars.appBar
+                  .topMargin]: `calc(${globalVars.appBar.height} + max(${globalVars.appBar.minSafeAreaInsetTop}, env(safe-area-inset-top)))`,
+              },
             },
           },
         },


### PR DESCRIPTION
Fixes a bug introduced by #479 which results in height larger than the actual screen when the device has safe-area-inset-top value other than 0.