### PR TITLE
feat(plugin-basic-ui): add interface to access z-index about AppScreen

### DIFF
--- a/.changeset/chilled-items-protect.md
+++ b/.changeset/chilled-items-protect.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-basic-ui": minor
+---
+
+feat(plugin-basic-ui): add interface to access z-index about AppScreen

--- a/extensions/plugin-basic-ui/src/components/AppScreen.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.tsx
@@ -131,14 +131,14 @@ const AppScreen: React.FC<AppScreenProps> = ({
             opacity: "1",
           }
         : activityEnterStyle === "slideInLeft"
-        ? {
-            transform: "translate3d(-50%, 0, 0)",
-            opacity: "0",
-          }
-        : {
-            transform: `translate3d(0, -${OFFSET_PX_ANDROID / 16}rem, 0)`,
-            opacity: "1",
-          },
+          ? {
+              transform: "translate3d(-50%, 0, 0)",
+              opacity: "0",
+            }
+          : {
+              transform: `translate3d(0, -${OFFSET_PX_ANDROID / 16}rem, 0)`,
+              opacity: "1",
+            },
     transitionDuration: globalVars.computedTransitionDuration,
     hasEffect: modalPresentationStyle !== "fullScreen",
   });

--- a/extensions/plugin-basic-ui/src/components/AppScreen.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.tsx
@@ -24,6 +24,12 @@ export const OFFSET_PX_CUPERTINO = 80;
 
 export type AppScreenContext = {
   scroll: (args: { top: number }) => void;
+  zIndices: {
+    dim: number;
+    paper: number;
+    edge: number;
+    appBar: number;
+  };
 };
 const Context = createContext<AppScreenContext>(null as any);
 
@@ -125,14 +131,14 @@ const AppScreen: React.FC<AppScreenProps> = ({
             opacity: "1",
           }
         : activityEnterStyle === "slideInLeft"
-          ? {
-              transform: "translate3d(-50%, 0, 0)",
-              opacity: "0",
-            }
-          : {
-              transform: `translate3d(0, -${OFFSET_PX_ANDROID / 16}rem, 0)`,
-              opacity: "1",
-            },
+        ? {
+            transform: "translate3d(-50%, 0, 0)",
+            opacity: "0",
+          }
+        : {
+            transform: `translate3d(0, -${OFFSET_PX_ANDROID / 16}rem, 0)`,
+            opacity: "1",
+          },
     transitionDuration: globalVars.computedTransitionDuration,
     hasEffect: modalPresentationStyle !== "fullScreen",
   });
@@ -193,8 +199,14 @@ const AppScreen: React.FC<AppScreenProps> = ({
               behavior: "smooth",
             });
           },
+          zIndices: {
+            dim: zIndexDim,
+            paper: zIndexPaper,
+            edge: zIndexEdge,
+            appBar: zIndexAppBar,
+          },
         }),
-        [paperRef],
+        [paperRef, zIndexDim, zIndexPaper, zIndexEdge, zIndexAppBar],
       )}
     >
       <div


### PR DESCRIPTION
AppScreen 및 관련 요소들은 z-index를 사용해 스택형 UI를 구현하고 있습니다.

현재 인터페이스에서는 Popover와 같은 floating 요소를 제어할 때 "AppScreen보다 높아야 하지만, AppBar에는 가려져야 한다." 와 같은 요구사항을 해결하기 어려운 문제가 있습니다.

따라서, `useAppScreen()`에 `zIndices` 정보를 추가해 하위 컴포넌트에서 `zIndex: zIndices.appBar - 1` 과 같이 사용할 수 있도록 합니다.