### PR TITLE
feat(config): added `RegisterActivityLoaderArgs` interface

### DIFF
--- a/.changeset/rotten-flowers-lie.md
+++ b/.changeset/rotten-flowers-lie.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/config": minor
+---
+
+Added RegisterActivityLoaderArgs interface

--- a/.changeset/shy-insects-hear.md
+++ b/.changeset/shy-insects-hear.md
@@ -1,0 +1,6 @@
+---
+"@stackflow/react": minor
+"@stackflow/config": minor
+---
+
+Added activityLoaderArgs in config and pass args in loaderPlugin

--- a/config/src/ActivityLoaderArgs.ts
+++ b/config/src/ActivityLoaderArgs.ts
@@ -1,8 +1,9 @@
 import type { InferActivityParams } from "./InferActivityParams";
 import type { RegisteredActivityParamTypes } from "./RegisteredActivityParamTypes";
+import type { RegisterActivityLoaderArgs } from "./RegisterActivityLoaderArgs"
 
-export type ActivityLoaderArgs<
+export interface ActivityLoaderArgs<
   ActivityName extends Extract<keyof RegisteredActivityParamTypes, string>,
-> = {
-  params: InferActivityParams<ActivityName>;
+> extends RegisterActivityLoaderArgs {
+  params?: InferActivityParams<ActivityName>;
 };

--- a/config/src/ActivityLoaderArgs.ts
+++ b/config/src/ActivityLoaderArgs.ts
@@ -5,5 +5,5 @@ import type { RegisterActivityLoaderArgs } from "./RegisterActivityLoaderArgs"
 export interface ActivityLoaderArgs<
   ActivityName extends Extract<keyof RegisteredActivityParamTypes, string>,
 > extends RegisterActivityLoaderArgs {
-  params?: InferActivityParams<ActivityName>;
+  params: InferActivityParams<ActivityName>;
 };

--- a/config/src/Config.ts
+++ b/config/src/Config.ts
@@ -1,7 +1,14 @@
 import type { ActivityDefinition } from "./ActivityDefinition";
+import type { RegisterActivityLoaderArgs } from "./RegisterActivityLoaderArgs";
+
+interface ActivityLoaderArgsConfig {
+  activityLoaderArgs: RegisterActivityLoaderArgs;
+}
 
 export type Config<T extends ActivityDefinition<string>> = {
   activities: T[];
   transitionDuration: number;
   initialActivity?: () => T["name"];
-};
+} & (keyof RegisterActivityLoaderArgs extends never
+  ? {}
+  : ActivityLoaderArgsConfig);

--- a/config/src/RegisterActivityLoaderArgs.ts
+++ b/config/src/RegisterActivityLoaderArgs.ts
@@ -1,0 +1,2 @@
+// biome-ignore lint/suspicious/noEmptyInterface: declaration merging
+export interface RegisterActivityLoaderArgs {}

--- a/config/src/index.ts
+++ b/config/src/index.ts
@@ -6,4 +6,5 @@ export * from "./ActivityLoaderArgs";
 export * from "./Config";
 export * from "./InferActivityParams";
 export * from "./Register";
+export * from "./RegisterActivityLoaderArgs"
 export * from "./RegisteredActivityParamTypes";

--- a/integrations/react/src/future/loader/loaderPlugin.tsx
+++ b/integrations/react/src/future/loader/loaderPlugin.tsx
@@ -37,8 +37,14 @@ export function loaderPlugin(
           return event;
         }
 
+        const activityLoaderArgs =
+          "activityLoaderArgs" in config
+            ? (config.activityLoaderArgs as object)
+            : {};
+
         const loaderData = loader({
           params: activityParams,
+          ...activityLoaderArgs,
         });
 
         return {
@@ -61,8 +67,14 @@ export function loaderPlugin(
         return;
       }
 
+      const activityLoaderArgs =
+        "activityLoaderArgs" in config
+          ? (config.activityLoaderArgs as object)
+          : {};
+
       const loaderData = loader({
         params: activityParams,
+        ...activityLoaderArgs,
       });
 
       overrideActionParams({
@@ -84,8 +96,14 @@ export function loaderPlugin(
         return;
       }
 
+      const activityLoaderArgs =
+        "activityLoaderArgs" in config
+          ? (config.activityLoaderArgs as object)
+          : {};
+
       const loaderData = loader({
         params: activityParams,
+        ...activityLoaderArgs,
       });
 
       overrideActionParams({


### PR DESCRIPTION
### Backgrounds

As an user, I want to do something in activity loader function with a client likes Relay or TanStack Query and avoid import it directly.

### Description

Added `RegisterActivityLoadersArgs` interface to extends `ActivityLoaderArgs`.

### Changes

- Added `RegisterActivityLoaderArgs` interface.
- Update `ActivityLoaderArgs` interface to be extend `RegisterActivityLoaderArgs` interface.
  - And change type declaration keyword to `interface` from `type` to be uses `extends` keyword.

### To-Do

- [x] Pass extends loader args in overrideInitialEvents/onBeforePush/onBeforeReplace cycle. (loaderPlugin)
- [ ] Need changes in preloadPlugin?