### PR TITLE
feat: Add feature makeActivitiesReducers of Popped

### DIFF
--- a/core/src/activity-utils/makeActivitiesReducers.ts
+++ b/core/src/activity-utils/makeActivitiesReducers.ts
@@ -24,14 +24,14 @@ export const makeActivitiesReducers = (isTransitionDone: boolean) =>
      */
     Initialized: (
       activities: Activity[],
-      event: InitializedEvent,
+      event: InitializedEvent
     ): Activity[] => activities,
     /**
      * noop
      */
     ActivityRegistered: (
       activities: Activity[],
-      event: ActivityRegisteredEvent,
+      event: ActivityRegisteredEvent
     ): Activity[] => activities,
     /**
      * Push new activity to activities
@@ -68,10 +68,11 @@ export const makeActivitiesReducers = (isTransitionDone: boolean) =>
       ];
     },
     /**
-     * noop
+     * Pop the last activity from activities
      */
-    Popped: (activities: Activity[], event: PoppedEvent): Activity[] =>
-      activities,
+    Popped: (activities: Activity[], event: PoppedEvent): Activity[] => {
+      return activities.slice(0, activities.length - 1);
+    },
     /**
      * noop
      */
@@ -82,7 +83,7 @@ export const makeActivitiesReducers = (isTransitionDone: boolean) =>
      */
     StepReplaced: (
       activities: Activity[],
-      event: StepReplacedEvent,
+      event: StepReplacedEvent
     ): Activity[] => activities,
     /**
      * noop


### PR DESCRIPTION
안녕하세요,
Stackflow를 활용한 프로젝트를 진행하면서, 발견한 문제에 대해 확인 요청을 드리고자 pull request를 남기게 되었습니다.

해당 문서 (https://stackflow.so/guided-tour/state) 에서는
stack.activities와 관련하여,

```
const stack = useStack();
console.log("현재 쌓여진 액티비티들:", stack.activities);
```

를 통해, 현재 쌓여진 액티비티들을 확인할 수 있다는 부분이 기술되어 있다고 설명하고 있습니다. 
이에 따라 액티비티 목록을 출력해보는 작업을 진행하였고, 그 과정에서 이상한 점을 발견하였습니다.


push를 통해 액티비티가 정상적으로 추가되는 것과는 달리, 
pop을 했을 때 마지막 액티비티가 여전히 목록에 남아있는 문제인데,

코드를 살펴본 결과, push 및 replace에 대해서는 액티비티 배열이 변경되지만, 
pop을 할 때는 현재 쌓여진 액티비티 목록에서 해당 액티비티를 제거하는 로직이 없다는 것을 확인하였습니다.

</br>   </br>   

이러한 문제를 해결하기 위해
아래 코드와 같이, pop할 때 마지막 액티비티가 제거되도록 하는 로직이 필요하다고 생각하여 코드를 수정해보았습니다. 
```
/**
 * Pop the last activity from activities
 */
Popped: (activities: Activity[], event: PoppedEvent): Activity[] => {
  return activities.slice(0, activities.length - 1);
},
```
(만약 이 로직이 없다면, 배열에서 액티비티가 사라지지 않고 계속 쌓이게 되어, 메모리 문제를 일으킬 가능성도 있습니다고 생각합니다.)

제가 아직 초보 개발자라 잘 모르는 부분이 많은데, 
혹시 이 부분에 대해 확인이 가능하실지 알 수 있을까요?
감사합니다.