### PR TITLE
feat(react): Add option `useDeferredStack` to disable use of `useDeferredValue`

### DIFF
--- a/.changeset/honest-gorillas-pretend.md
+++ b/.changeset/honest-gorillas-pretend.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/react": patch
+---
+
+feat(react): Add option `useDeferredStack` to disable use of `useDeferredValue`

--- a/integrations/react/src/__internal__/core/CoreProvider.tsx
+++ b/integrations/react/src/__internal__/core/CoreProvider.tsx
@@ -1,8 +1,6 @@
 import type { CoreStore, Stack } from "@stackflow/core";
 import { createContext } from "react";
 
-import { useDeferredValue, useSyncExternalStore } from "../shims";
-
 export const CoreActionsContext = createContext<CoreStore["actions"]>(
   null as any,
 );
@@ -10,22 +8,16 @@ export const CoreStateContext = createContext<Stack>(null as any);
 
 export interface CoreProviderProps {
   coreStore: CoreStore;
+  coreState: Stack;
   children: React.ReactNode;
 }
 export const CoreProvider: React.FC<CoreProviderProps> = ({
   coreStore,
+  coreState,
   children,
 }) => {
-  const stack = useSyncExternalStore(
-    coreStore.subscribe,
-    coreStore.actions.getStack,
-    coreStore.actions.getStack,
-  );
-
-  const deferredStack = useDeferredValue(stack);
-
   return (
-    <CoreStateContext.Provider value={deferredStack}>
+    <CoreStateContext.Provider value={coreState}>
       <CoreActionsContext.Provider value={coreStore.actions}>
         {children}
       </CoreActionsContext.Provider>


### PR DESCRIPTION
## Note

The part that integrates coreStore with React and changes it to State has been moved from the existing Provider to the top of the <Stack /> component.