### PR TITLE
feat(plugin-sentry): add plugin for sentry

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -124,7 +124,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@biomejs/biome", "npm:1.8.3"],\
           ["@changesets/cli", "npm:2.27.7"],\
-          ["@sentry/browser", "npm:8.41.0"],\
           ["@types/jest", "npm:29.5.12"],\
           ["@types/node", "npm:20.14.9"],\
           ["@types/react", "npm:18.3.3"],\
@@ -2762,15 +2761,6 @@ const RAW_RUNTIME_STATE =
           ["@sentry/types", "npm:8.40.0"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:8.41.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-internal-browser-utils-npm-8.41.0-14f985e7e9-118f594bc0.zip/node_modules/@sentry-internal/browser-utils/",\
-        "packageDependencies": [\
-          ["@sentry-internal/browser-utils", "npm:8.41.0"],\
-          ["@sentry/core", "npm:8.41.0"],\
-          ["@sentry/types", "npm:8.41.0"]\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["@sentry-internal/feedback", [\
@@ -2780,15 +2770,6 @@ const RAW_RUNTIME_STATE =
           ["@sentry-internal/feedback", "npm:8.40.0"],\
           ["@sentry/core", "npm:8.40.0"],\
           ["@sentry/types", "npm:8.40.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:8.41.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-internal-feedback-npm-8.41.0-acee7dee44-0d546a0d8a.zip/node_modules/@sentry-internal/feedback/",\
-        "packageDependencies": [\
-          ["@sentry-internal/feedback", "npm:8.41.0"],\
-          ["@sentry/core", "npm:8.41.0"],\
-          ["@sentry/types", "npm:8.41.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2803,16 +2784,6 @@ const RAW_RUNTIME_STATE =
           ["@sentry/types", "npm:8.40.0"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:8.41.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-internal-replay-npm-8.41.0-b033a0308d-046b0b5d55.zip/node_modules/@sentry-internal/replay/",\
-        "packageDependencies": [\
-          ["@sentry-internal/replay", "npm:8.41.0"],\
-          ["@sentry-internal/browser-utils", "npm:8.41.0"],\
-          ["@sentry/core", "npm:8.41.0"],\
-          ["@sentry/types", "npm:8.41.0"]\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["@sentry-internal/replay-canvas", [\
@@ -2823,16 +2794,6 @@ const RAW_RUNTIME_STATE =
           ["@sentry-internal/replay", "npm:8.40.0"],\
           ["@sentry/core", "npm:8.40.0"],\
           ["@sentry/types", "npm:8.40.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:8.41.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-internal-replay-canvas-npm-8.41.0-448144ec6b-e9898d37ea.zip/node_modules/@sentry-internal/replay-canvas/",\
-        "packageDependencies": [\
-          ["@sentry-internal/replay-canvas", "npm:8.41.0"],\
-          ["@sentry-internal/replay", "npm:8.41.0"],\
-          ["@sentry/core", "npm:8.41.0"],\
-          ["@sentry/types", "npm:8.41.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2850,19 +2811,6 @@ const RAW_RUNTIME_STATE =
           ["@sentry/types", "npm:8.40.0"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:8.41.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-browser-npm-8.41.0-2d393d4c10-c5cf890b3f.zip/node_modules/@sentry/browser/",\
-        "packageDependencies": [\
-          ["@sentry/browser", "npm:8.41.0"],\
-          ["@sentry-internal/browser-utils", "npm:8.41.0"],\
-          ["@sentry-internal/feedback", "npm:8.41.0"],\
-          ["@sentry-internal/replay", "npm:8.41.0"],\
-          ["@sentry-internal/replay-canvas", "npm:8.41.0"],\
-          ["@sentry/core", "npm:8.41.0"],\
-          ["@sentry/types", "npm:8.41.0"]\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["@sentry/core", [\
@@ -2873,14 +2821,6 @@ const RAW_RUNTIME_STATE =
           ["@sentry/types", "npm:8.40.0"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:8.41.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-core-npm-8.41.0-26db961fb9-76dceda22e.zip/node_modules/@sentry/core/",\
-        "packageDependencies": [\
-          ["@sentry/core", "npm:8.41.0"],\
-          ["@sentry/types", "npm:8.41.0"]\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["@sentry/types", [\
@@ -2888,13 +2828,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/@sentry-types-npm-8.40.0-f6513bfb87-6fba146cbd.zip/node_modules/@sentry/types/",\
         "packageDependencies": [\
           ["@sentry/types", "npm:8.40.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:8.41.0", {\
-        "packageLocation": "./.yarn/cache/@sentry-types-npm-8.41.0-2e415d7dfe-50e1a938be.zip/node_modules/@sentry/types/",\
-        "packageDependencies": [\
-          ["@sentry/types", "npm:8.41.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -3011,7 +2944,6 @@ const RAW_RUNTIME_STATE =
           ["@stackflow/demo", "workspace:demo"],\
           ["@seed-design/design-token", "npm:1.0.3"],\
           ["@seed-design/stylesheet", "npm:1.0.4"],\
-          ["@sentry/browser", "npm:8.41.0"],\
           ["@stackflow/compat-await-push", "virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/compat-await-push"],\
           ["@stackflow/config", "workspace:config"],\
           ["@stackflow/core", "workspace:core"],\
@@ -3155,7 +3087,6 @@ const RAW_RUNTIME_STATE =
           ["@stackflow/monorepo", "workspace:."],\
           ["@biomejs/biome", "npm:1.8.3"],\
           ["@changesets/cli", "npm:2.27.7"],\
-          ["@sentry/browser", "npm:8.41.0"],\
           ["@types/jest", "npm:29.5.12"],\
           ["@types/node", "npm:20.14.9"],\
           ["@types/react", "npm:18.3.3"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -71,6 +71,10 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:extensions/plugin-renderer-web"\
     },\
     {\
+      "name": "@stackflow/plugin-sentry",\
+      "reference": "workspace:extensions/plugin-sentry"\
+    },\
+    {\
       "name": "@stackflow/plugin-stack-depth-change",\
       "reference": "workspace:extensions/plugin-stack-depth-change"\
     },\
@@ -106,6 +110,7 @@ const RAW_RUNTIME_STATE =
     ["@stackflow/plugin-preload", ["virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/plugin-preload", "workspace:extensions/plugin-preload"]],\
     ["@stackflow/plugin-renderer-basic", ["virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/plugin-renderer-basic", "workspace:extensions/plugin-renderer-basic"]],\
     ["@stackflow/plugin-renderer-web", ["workspace:extensions/plugin-renderer-web"]],\
+    ["@stackflow/plugin-sentry", ["workspace:extensions/plugin-sentry"]],\
     ["@stackflow/plugin-stack-depth-change", ["virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/plugin-stack-depth-change", "workspace:extensions/plugin-stack-depth-change"]],\
     ["@stackflow/react", ["virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:integrations/react", "workspace:integrations/react"]],\
     ["@stackflow/react-ui-core", ["virtual:669046a185e83900af978519e5adddf8e8f1f8fed824849248ba56cf8fcd4e4208872f27e14c3c844d3b769f42be1ba6e0aa90f12df9fa6c38a55aedee211f53#workspace:extensions/react-ui-core", "workspace:extensions/react-ui-core"]]\
@@ -119,6 +124,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@biomejs/biome", "npm:1.8.3"],\
           ["@changesets/cli", "npm:2.27.7"],\
+          ["@sentry/browser", "npm:8.41.0"],\
           ["@types/jest", "npm:29.5.12"],\
           ["@types/node", "npm:20.14.9"],\
           ["@types/react", "npm:18.3.3"],\
@@ -2747,6 +2753,152 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@sentry-internal/browser-utils", [\
+      ["npm:8.40.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-internal-browser-utils-npm-8.40.0-0cb16ce8b5-b5f3bd4a8c.zip/node_modules/@sentry-internal/browser-utils/",\
+        "packageDependencies": [\
+          ["@sentry-internal/browser-utils", "npm:8.40.0"],\
+          ["@sentry/core", "npm:8.40.0"],\
+          ["@sentry/types", "npm:8.40.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:8.41.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-internal-browser-utils-npm-8.41.0-14f985e7e9-118f594bc0.zip/node_modules/@sentry-internal/browser-utils/",\
+        "packageDependencies": [\
+          ["@sentry-internal/browser-utils", "npm:8.41.0"],\
+          ["@sentry/core", "npm:8.41.0"],\
+          ["@sentry/types", "npm:8.41.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@sentry-internal/feedback", [\
+      ["npm:8.40.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-internal-feedback-npm-8.40.0-5547bafbc9-98e16aead7.zip/node_modules/@sentry-internal/feedback/",\
+        "packageDependencies": [\
+          ["@sentry-internal/feedback", "npm:8.40.0"],\
+          ["@sentry/core", "npm:8.40.0"],\
+          ["@sentry/types", "npm:8.40.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:8.41.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-internal-feedback-npm-8.41.0-acee7dee44-0d546a0d8a.zip/node_modules/@sentry-internal/feedback/",\
+        "packageDependencies": [\
+          ["@sentry-internal/feedback", "npm:8.41.0"],\
+          ["@sentry/core", "npm:8.41.0"],\
+          ["@sentry/types", "npm:8.41.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@sentry-internal/replay", [\
+      ["npm:8.40.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-internal-replay-npm-8.40.0-bbc525e042-c2edb588f8.zip/node_modules/@sentry-internal/replay/",\
+        "packageDependencies": [\
+          ["@sentry-internal/replay", "npm:8.40.0"],\
+          ["@sentry-internal/browser-utils", "npm:8.40.0"],\
+          ["@sentry/core", "npm:8.40.0"],\
+          ["@sentry/types", "npm:8.40.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:8.41.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-internal-replay-npm-8.41.0-b033a0308d-046b0b5d55.zip/node_modules/@sentry-internal/replay/",\
+        "packageDependencies": [\
+          ["@sentry-internal/replay", "npm:8.41.0"],\
+          ["@sentry-internal/browser-utils", "npm:8.41.0"],\
+          ["@sentry/core", "npm:8.41.0"],\
+          ["@sentry/types", "npm:8.41.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@sentry-internal/replay-canvas", [\
+      ["npm:8.40.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-internal-replay-canvas-npm-8.40.0-26450868fb-b219783f8b.zip/node_modules/@sentry-internal/replay-canvas/",\
+        "packageDependencies": [\
+          ["@sentry-internal/replay-canvas", "npm:8.40.0"],\
+          ["@sentry-internal/replay", "npm:8.40.0"],\
+          ["@sentry/core", "npm:8.40.0"],\
+          ["@sentry/types", "npm:8.40.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:8.41.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-internal-replay-canvas-npm-8.41.0-448144ec6b-e9898d37ea.zip/node_modules/@sentry-internal/replay-canvas/",\
+        "packageDependencies": [\
+          ["@sentry-internal/replay-canvas", "npm:8.41.0"],\
+          ["@sentry-internal/replay", "npm:8.41.0"],\
+          ["@sentry/core", "npm:8.41.0"],\
+          ["@sentry/types", "npm:8.41.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@sentry/browser", [\
+      ["npm:8.40.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-browser-npm-8.40.0-500840aa49-fe0bf8a598.zip/node_modules/@sentry/browser/",\
+        "packageDependencies": [\
+          ["@sentry/browser", "npm:8.40.0"],\
+          ["@sentry-internal/browser-utils", "npm:8.40.0"],\
+          ["@sentry-internal/feedback", "npm:8.40.0"],\
+          ["@sentry-internal/replay", "npm:8.40.0"],\
+          ["@sentry-internal/replay-canvas", "npm:8.40.0"],\
+          ["@sentry/core", "npm:8.40.0"],\
+          ["@sentry/types", "npm:8.40.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:8.41.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-browser-npm-8.41.0-2d393d4c10-c5cf890b3f.zip/node_modules/@sentry/browser/",\
+        "packageDependencies": [\
+          ["@sentry/browser", "npm:8.41.0"],\
+          ["@sentry-internal/browser-utils", "npm:8.41.0"],\
+          ["@sentry-internal/feedback", "npm:8.41.0"],\
+          ["@sentry-internal/replay", "npm:8.41.0"],\
+          ["@sentry-internal/replay-canvas", "npm:8.41.0"],\
+          ["@sentry/core", "npm:8.41.0"],\
+          ["@sentry/types", "npm:8.41.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@sentry/core", [\
+      ["npm:8.40.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-core-npm-8.40.0-389ff0edb3-450e2d3514.zip/node_modules/@sentry/core/",\
+        "packageDependencies": [\
+          ["@sentry/core", "npm:8.40.0"],\
+          ["@sentry/types", "npm:8.40.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:8.41.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-core-npm-8.41.0-26db961fb9-76dceda22e.zip/node_modules/@sentry/core/",\
+        "packageDependencies": [\
+          ["@sentry/core", "npm:8.41.0"],\
+          ["@sentry/types", "npm:8.41.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@sentry/types", [\
+      ["npm:8.40.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-types-npm-8.40.0-f6513bfb87-6fba146cbd.zip/node_modules/@sentry/types/",\
+        "packageDependencies": [\
+          ["@sentry/types", "npm:8.40.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:8.41.0", {\
+        "packageLocation": "./.yarn/cache/@sentry-types-npm-8.41.0-2e415d7dfe-50e1a938be.zip/node_modules/@sentry/types/",\
+        "packageDependencies": [\
+          ["@sentry/types", "npm:8.41.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@sinclair/typebox", [\
       ["npm:0.27.8", {\
         "packageLocation": "./.yarn/cache/@sinclair-typebox-npm-0.27.8-23e206d653-297f95ff77.zip/node_modules/@sinclair/typebox/",\
@@ -2859,6 +3011,7 @@ const RAW_RUNTIME_STATE =
           ["@stackflow/demo", "workspace:demo"],\
           ["@seed-design/design-token", "npm:1.0.3"],\
           ["@seed-design/stylesheet", "npm:1.0.4"],\
+          ["@sentry/browser", "npm:8.41.0"],\
           ["@stackflow/compat-await-push", "virtual:413bca98ff76262f6f1f73762ccc4b7edee04a5da42f3d6b9ed2cb2d6dbc397b2094da59b50f6e828091c88e7b5f86990feff596c43f0eb50a58fc42aae64a20#workspace:extensions/compat-await-push"],\
           ["@stackflow/config", "workspace:config"],\
           ["@stackflow/core", "workspace:core"],\
@@ -3002,6 +3155,7 @@ const RAW_RUNTIME_STATE =
           ["@stackflow/monorepo", "workspace:."],\
           ["@biomejs/biome", "npm:1.8.3"],\
           ["@changesets/cli", "npm:2.27.7"],\
+          ["@sentry/browser", "npm:8.41.0"],\
           ["@types/jest", "npm:29.5.12"],\
           ["@types/node", "npm:20.14.9"],\
           ["@types/react", "npm:18.3.3"],\
@@ -3328,6 +3482,22 @@ const RAW_RUNTIME_STATE =
           ["esbuild", "npm:0.23.0"],\
           ["react", "npm:18.3.1"],\
           ["rimraf", "npm:3.0.2"],\
+          ["typescript", "patch:typescript@npm%3A5.5.3#optional!builtin<compat/typescript>::version=5.5.3&hash=379a07"]\
+        ],\
+        "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@stackflow/plugin-sentry", [\
+      ["workspace:extensions/plugin-sentry", {\
+        "packageLocation": "./extensions/plugin-sentry/",\
+        "packageDependencies": [\
+          ["@stackflow/plugin-sentry", "workspace:extensions/plugin-sentry"],\
+          ["@sentry/browser", "npm:8.40.0"],\
+          ["@sentry/core", "npm:8.40.0"],\
+          ["@sentry/types", "npm:8.40.0"],\
+          ["@stackflow/core", "workspace:core"],\
+          ["@stackflow/esbuild-config", "workspace:packages/esbuild-config"],\
+          ["esbuild", "npm:0.23.0"],\
           ["typescript", "patch:typescript@npm%3A5.5.3#optional!builtin<compat/typescript>::version=5.5.3&hash=379a07"]\
         ],\
         "linkType": "SOFT"\

--- a/extensions/plugin-sentry/README.md
+++ b/extensions/plugin-sentry/README.md
@@ -1,0 +1,1 @@
+# plugin-sentry

--- a/extensions/plugin-sentry/README.md
+++ b/extensions/plugin-sentry/README.md
@@ -1,1 +1,25 @@
 # plugin-sentry
+
+Add Sentry plugin for analysis tracing activity events
+
+## Initialize
+
+
+```typescript
+import { stackflow } from "@stackflow/react";
+import { sentryPlugin } from "@stackflow/plugin-sentry";
+
+const { Stack, useFlow } = stackflow({
+  activities: {
+    // ...
+  },
+  plugins: [
+    sentryPlugin({
+      dsn: "https://xxx.ingest.us.sentry.io/xxx", // Sentry project dsn key
+      // ... 
+      // Additional Options for initiate Sentry
+      // https://docs.sentry.io/platforms/javascript/configuration/options/
+    }),
+  ],
+});
+```

--- a/extensions/plugin-sentry/esbuild.config.js
+++ b/extensions/plugin-sentry/esbuild.config.js
@@ -1,0 +1,29 @@
+const { context } = require("esbuild");
+const config = require("@stackflow/esbuild-config");
+const pkg = require("./package.json");
+
+const watch = process.argv.includes("--watch");
+const external = Object.keys({
+  ...pkg.dependencies,
+  ...pkg.peerDependencies,
+});
+
+Promise.all([
+  context({
+    ...config({}),
+    format: "cjs",
+    external,
+  }).then((ctx) =>
+    watch ? ctx.watch() : ctx.rebuild().then(() => ctx.dispose()),
+  ),
+  context({
+    ...config({}),
+    format: "esm",
+    outExtension: {
+      ".js": ".mjs",
+    },
+    external,
+  }).then((ctx) =>
+    watch ? ctx.watch() : ctx.rebuild().then(() => ctx.dispose()),
+  ),
+]).catch(() => process.exit(1));

--- a/extensions/plugin-sentry/package.json
+++ b/extensions/plugin-sentry/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@stackflow/plugin-sentry",
+  "version": "0,0,0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/daangn/stackflow.git",
+    "directory": "extensions/plugin-sentry"
+  },
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "yarn build:js && yarn build:dts",
+    "build:dts": "tsc --emitDeclarationOnly",
+    "build:js": "node ./esbuild.config.js",
+    "clean": "rimraf dist",
+    "dev": "yarn build:js --watch && yarn build:dts --watch"
+  },
+  "devDependencies": {
+    "@sentry/types": "^8.37.1",
+    "@stackflow/core": "^1.1.0",
+    "@stackflow/esbuild-config": "^1.0.3",
+    "esbuild": "^0.23.0",
+    "typescript": "^5.5.3"
+  },
+  "dependencies": {
+    "@sentry/browser": "^8.37.1",
+    "@sentry/core": "^8.37.1"
+  }
+}

--- a/extensions/plugin-sentry/src/index.ts
+++ b/extensions/plugin-sentry/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./sentryPlugin";

--- a/extensions/plugin-sentry/src/integration.ts
+++ b/extensions/plugin-sentry/src/integration.ts
@@ -1,0 +1,43 @@
+import {
+  WINDOW,
+  browserTracingIntegration as originalBrowserTracingIntegration,
+  startBrowserTracingPageLoadSpan,
+} from "@sentry/browser";
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+} from "@sentry/core";
+
+import type { Integration } from "@sentry/types";
+
+export function stackflowBrowserTracingIntegration(
+  options: Parameters<typeof originalBrowserTracingIntegration>[0] = {},
+): Integration {
+  const browserTracingIntegrationInstance = originalBrowserTracingIntegration({
+    ...options,
+    instrumentNavigation: false,
+    instrumentPageLoad: false,
+  });
+  const { instrumentPageLoad = true } = options;
+
+  return {
+    ...browserTracingIntegrationInstance,
+    afterAllSetup(client) {
+      browserTracingIntegrationInstance.afterAllSetup(client);
+
+      const initialWindowLocation = WINDOW.location;
+
+      if (instrumentPageLoad && initialWindowLocation) {
+        startBrowserTracingPageLoadSpan(client, {
+          name: initialWindowLocation.pathname,
+          attributes: {
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: "pageload",
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: "auto.pageload.stackflow",
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: "url",
+          },
+        });
+      }
+    },
+  };
+}

--- a/extensions/plugin-sentry/src/sentryPlugin.ts
+++ b/extensions/plugin-sentry/src/sentryPlugin.ts
@@ -1,0 +1,81 @@
+import * as Sentry from "@sentry/browser";
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  getClient,
+} from "@sentry/core";
+import type {
+  DomainEvent,
+  Effect,
+  Stack,
+  StackflowActions,
+  StackflowPlugin,
+} from "@stackflow/core";
+
+import type { Integration } from "@sentry/types";
+import { stackflowBrowserTracingIntegration } from "./integration";
+
+export function sentryPlugin(): StackflowPlugin {
+  return () => ({
+    key: "plugin-sentry",
+    onInit() {
+      Sentry.init({
+        dsn: "https://de8235db42e3f12757ff2ab2e5f5b75f@o4508278402187264.ingest.us.sentry.io/4508279653728256",
+        integrations: [
+          /**
+           * make integration
+           */
+          stackflowBrowserTracingIntegration(),
+          Sentry.replayIntegration(),
+        ],
+        // Tracing
+        tracesSampleRate: 1.0, //  Capture 100% of the transactions
+        // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
+        tracePropagationTargets: [
+          "localhost",
+          /^https:\/\/yourserver\.io\/api/,
+        ],
+        // Session Replay
+        replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+        replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+      });
+    },
+    onPushed({ effect }) {
+      const client = getClient();
+      if (!client) return;
+      Sentry.startBrowserTracingNavigationSpan(client, {
+        name: `push ${effect.activity.name}`,
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: "navigation",
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: "auto.navigation.stackflow",
+          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: "route",
+        },
+      });
+    },
+    onPopped({ effect }) {
+      const client = getClient();
+      if (!client) return;
+      Sentry.startBrowserTracingNavigationSpan(client, {
+        name: `pop ${effect.activity.name}`,
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: "navigation",
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: "auto.navigation.stackflow",
+          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: "route",
+        },
+      });
+    },
+    onReplaced({ effect }) {
+      const client = getClient();
+      if (!client) return;
+      Sentry.startBrowserTracingNavigationSpan(client, {
+        name: `replace ${effect.activity.name}`,
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: "navigation",
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: "auto.navigation.stackflow",
+          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: "route",
+        },
+      });
+    },
+  });
+}

--- a/extensions/plugin-sentry/src/sentryPlugin.ts
+++ b/extensions/plugin-sentry/src/sentryPlugin.ts
@@ -1,11 +1,11 @@
 import * as Sentry from "@sentry/browser";
-import type { BrowserOptions} from "@sentry/browser";
+import type { BrowserOptions } from "@sentry/browser";
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from "@sentry/core";
-import { Integration } from "@sentry/types";
+import type { Integration } from "@sentry/types";
 import type {
   DomainEvent,
   Effect,

--- a/extensions/plugin-sentry/tsconfig.json
+++ b/extensions/plugin-sentry/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["./dist"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,16 +1980,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/browser-utils@npm:8.41.0":
-  version: 8.41.0
-  resolution: "@sentry-internal/browser-utils@npm:8.41.0"
-  dependencies:
-    "@sentry/core": "npm:8.41.0"
-    "@sentry/types": "npm:8.41.0"
-  checksum: 10/118f594bc042acda3522183ffc7200af44574ab6f458ddb02960f8a910bcbb75ae775ab57c453ade6924b5c7884825b61eaba6e7f97ff28230e4fc01dc90247c
-  languageName: node
-  linkType: hard
-
 "@sentry-internal/feedback@npm:8.40.0":
   version: 8.40.0
   resolution: "@sentry-internal/feedback@npm:8.40.0"
@@ -1997,16 +1987,6 @@ __metadata:
     "@sentry/core": "npm:8.40.0"
     "@sentry/types": "npm:8.40.0"
   checksum: 10/98e16aead7a5b635c83d826182f6f092debe0d4139a341929ba489d5fff92c82049ddc90de3a7252e04396912ac49a674e42dcd377136e971a65386950eb02e4
-  languageName: node
-  linkType: hard
-
-"@sentry-internal/feedback@npm:8.41.0":
-  version: 8.41.0
-  resolution: "@sentry-internal/feedback@npm:8.41.0"
-  dependencies:
-    "@sentry/core": "npm:8.41.0"
-    "@sentry/types": "npm:8.41.0"
-  checksum: 10/0d546a0d8a7c6e641ff662d65d696eacc0c089089d89b1d342f16bd8372207a385be32d88c6280f550de241f9130f616d7038deb62cee75b35ec3cd7700b02ec
   languageName: node
   linkType: hard
 
@@ -2021,17 +2001,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/replay-canvas@npm:8.41.0":
-  version: 8.41.0
-  resolution: "@sentry-internal/replay-canvas@npm:8.41.0"
-  dependencies:
-    "@sentry-internal/replay": "npm:8.41.0"
-    "@sentry/core": "npm:8.41.0"
-    "@sentry/types": "npm:8.41.0"
-  checksum: 10/e9898d37eacaa07ef08b51b341b9e24f726a85c0d2542e63bd543294960c16b48c87d2054afdac5fa2c15d24b7dac29c8078d2b8692dcd496ae6d11fcd18504b
-  languageName: node
-  linkType: hard
-
 "@sentry-internal/replay@npm:8.40.0":
   version: 8.40.0
   resolution: "@sentry-internal/replay@npm:8.40.0"
@@ -2040,17 +2009,6 @@ __metadata:
     "@sentry/core": "npm:8.40.0"
     "@sentry/types": "npm:8.40.0"
   checksum: 10/c2edb588f83ebfa99d2ee2702a9d1ca919cbb1a83539bfc279432f422e094d77741e4c07f5909a82d46ce619b4ed48fa04250546bd4f537868bd4519c87fb228
-  languageName: node
-  linkType: hard
-
-"@sentry-internal/replay@npm:8.41.0":
-  version: 8.41.0
-  resolution: "@sentry-internal/replay@npm:8.41.0"
-  dependencies:
-    "@sentry-internal/browser-utils": "npm:8.41.0"
-    "@sentry/core": "npm:8.41.0"
-    "@sentry/types": "npm:8.41.0"
-  checksum: 10/046b0b5d5552165f09b1d59a5b436ca3c6bc0de5acec4d910a6b6398a19c445e87aebfbb56747754124084fce1c8d4f237fb23e96971c41b3800e564611aae89
   languageName: node
   linkType: hard
 
@@ -2068,20 +2026,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:^8.41.0":
-  version: 8.41.0
-  resolution: "@sentry/browser@npm:8.41.0"
-  dependencies:
-    "@sentry-internal/browser-utils": "npm:8.41.0"
-    "@sentry-internal/feedback": "npm:8.41.0"
-    "@sentry-internal/replay": "npm:8.41.0"
-    "@sentry-internal/replay-canvas": "npm:8.41.0"
-    "@sentry/core": "npm:8.41.0"
-    "@sentry/types": "npm:8.41.0"
-  checksum: 10/c5cf890b3f9e32e9bdb7b5ebf22968e0e6a8813be4b6745c56d2e1f4874e196aede24d0084468c9bcc719d2ccb6daefadbc05cfef128ba3a5bf03cdca7347c5f
-  languageName: node
-  linkType: hard
-
 "@sentry/core@npm:8.40.0, @sentry/core@npm:^8.37.1":
   version: 8.40.0
   resolution: "@sentry/core@npm:8.40.0"
@@ -2091,26 +2035,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:8.41.0":
-  version: 8.41.0
-  resolution: "@sentry/core@npm:8.41.0"
-  dependencies:
-    "@sentry/types": "npm:8.41.0"
-  checksum: 10/76dceda22e6672c07462ad76b2b88d56cd3c677750cf6ee90e82f0e1b3826177f3c9f203dfed16dfee628eed8afaecb4b61d23942841604be310d53b84fbc11b
-  languageName: node
-  linkType: hard
-
 "@sentry/types@npm:8.40.0, @sentry/types@npm:^8.37.1":
   version: 8.40.0
   resolution: "@sentry/types@npm:8.40.0"
   checksum: 10/6fba146cbd9bc89a16d0fcd8cb01e441e9720f8a72bb390038bbf25b1c2feeb7b18de437b755a0e70bca113d66357771055b695305a8923527fba89e096ed931
-  languageName: node
-  linkType: hard
-
-"@sentry/types@npm:8.41.0":
-  version: 8.41.0
-  resolution: "@sentry/types@npm:8.41.0"
-  checksum: 10/50e1a938be11f8f6f1951617d7e0fe55b1ea55c3b2beceed43f928d3b669adb58166a4e4a5dcd5282883d4f20b2b8d3283df506b42076714d91d0563a49abea6
   languageName: node
   linkType: hard
 
@@ -2195,7 +2123,6 @@ __metadata:
   dependencies:
     "@seed-design/design-token": "npm:^1.0.3"
     "@seed-design/stylesheet": "npm:^1.0.4"
-    "@sentry/browser": "npm:^8.41.0"
     "@stackflow/compat-await-push": "npm:^1.1.13"
     "@stackflow/config": "npm:^1.2.0"
     "@stackflow/core": "npm:^1.1.0"
@@ -2303,7 +2230,6 @@ __metadata:
   dependencies:
     "@biomejs/biome": "npm:^1.8.3"
     "@changesets/cli": "npm:^2.27.7"
-    "@sentry/browser": "npm:^8.41.0"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.14.9"
     "@types/react": "npm:^18.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,6 +1970,150 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry-internal/browser-utils@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@sentry-internal/browser-utils@npm:8.40.0"
+  dependencies:
+    "@sentry/core": "npm:8.40.0"
+    "@sentry/types": "npm:8.40.0"
+  checksum: 10/b5f3bd4a8c043801a5567b75b585591f5f52343ffd865cb02b88d8b3b5e7af0fe59faa9945403ebf03af6b45bd7a6604643c670af51dbe2f4bf2040b22399241
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/browser-utils@npm:8.41.0":
+  version: 8.41.0
+  resolution: "@sentry-internal/browser-utils@npm:8.41.0"
+  dependencies:
+    "@sentry/core": "npm:8.41.0"
+    "@sentry/types": "npm:8.41.0"
+  checksum: 10/118f594bc042acda3522183ffc7200af44574ab6f458ddb02960f8a910bcbb75ae775ab57c453ade6924b5c7884825b61eaba6e7f97ff28230e4fc01dc90247c
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/feedback@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@sentry-internal/feedback@npm:8.40.0"
+  dependencies:
+    "@sentry/core": "npm:8.40.0"
+    "@sentry/types": "npm:8.40.0"
+  checksum: 10/98e16aead7a5b635c83d826182f6f092debe0d4139a341929ba489d5fff92c82049ddc90de3a7252e04396912ac49a674e42dcd377136e971a65386950eb02e4
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/feedback@npm:8.41.0":
+  version: 8.41.0
+  resolution: "@sentry-internal/feedback@npm:8.41.0"
+  dependencies:
+    "@sentry/core": "npm:8.41.0"
+    "@sentry/types": "npm:8.41.0"
+  checksum: 10/0d546a0d8a7c6e641ff662d65d696eacc0c089089d89b1d342f16bd8372207a385be32d88c6280f550de241f9130f616d7038deb62cee75b35ec3cd7700b02ec
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/replay-canvas@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@sentry-internal/replay-canvas@npm:8.40.0"
+  dependencies:
+    "@sentry-internal/replay": "npm:8.40.0"
+    "@sentry/core": "npm:8.40.0"
+    "@sentry/types": "npm:8.40.0"
+  checksum: 10/b219783f8b2768ba9fbeaa13452567eaa6d10f5180a311390032d9d6b19f645098ee15c1daac5b17177d5329db26c6825f87edf0cd67d40b223d0bea4e762375
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/replay-canvas@npm:8.41.0":
+  version: 8.41.0
+  resolution: "@sentry-internal/replay-canvas@npm:8.41.0"
+  dependencies:
+    "@sentry-internal/replay": "npm:8.41.0"
+    "@sentry/core": "npm:8.41.0"
+    "@sentry/types": "npm:8.41.0"
+  checksum: 10/e9898d37eacaa07ef08b51b341b9e24f726a85c0d2542e63bd543294960c16b48c87d2054afdac5fa2c15d24b7dac29c8078d2b8692dcd496ae6d11fcd18504b
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/replay@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@sentry-internal/replay@npm:8.40.0"
+  dependencies:
+    "@sentry-internal/browser-utils": "npm:8.40.0"
+    "@sentry/core": "npm:8.40.0"
+    "@sentry/types": "npm:8.40.0"
+  checksum: 10/c2edb588f83ebfa99d2ee2702a9d1ca919cbb1a83539bfc279432f422e094d77741e4c07f5909a82d46ce619b4ed48fa04250546bd4f537868bd4519c87fb228
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/replay@npm:8.41.0":
+  version: 8.41.0
+  resolution: "@sentry-internal/replay@npm:8.41.0"
+  dependencies:
+    "@sentry-internal/browser-utils": "npm:8.41.0"
+    "@sentry/core": "npm:8.41.0"
+    "@sentry/types": "npm:8.41.0"
+  checksum: 10/046b0b5d5552165f09b1d59a5b436ca3c6bc0de5acec4d910a6b6398a19c445e87aebfbb56747754124084fce1c8d4f237fb23e96971c41b3800e564611aae89
+  languageName: node
+  linkType: hard
+
+"@sentry/browser@npm:^8.37.1":
+  version: 8.40.0
+  resolution: "@sentry/browser@npm:8.40.0"
+  dependencies:
+    "@sentry-internal/browser-utils": "npm:8.40.0"
+    "@sentry-internal/feedback": "npm:8.40.0"
+    "@sentry-internal/replay": "npm:8.40.0"
+    "@sentry-internal/replay-canvas": "npm:8.40.0"
+    "@sentry/core": "npm:8.40.0"
+    "@sentry/types": "npm:8.40.0"
+  checksum: 10/fe0bf8a598dd366bc24a19bfe0ddf4c2b6a2998eab93f51a961a9136b3bfbda4a26610302e41d11520ba09efb27c101e1f3587af011fe09585a11f8605f75a2c
+  languageName: node
+  linkType: hard
+
+"@sentry/browser@npm:^8.41.0":
+  version: 8.41.0
+  resolution: "@sentry/browser@npm:8.41.0"
+  dependencies:
+    "@sentry-internal/browser-utils": "npm:8.41.0"
+    "@sentry-internal/feedback": "npm:8.41.0"
+    "@sentry-internal/replay": "npm:8.41.0"
+    "@sentry-internal/replay-canvas": "npm:8.41.0"
+    "@sentry/core": "npm:8.41.0"
+    "@sentry/types": "npm:8.41.0"
+  checksum: 10/c5cf890b3f9e32e9bdb7b5ebf22968e0e6a8813be4b6745c56d2e1f4874e196aede24d0084468c9bcc719d2ccb6daefadbc05cfef128ba3a5bf03cdca7347c5f
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:8.40.0, @sentry/core@npm:^8.37.1":
+  version: 8.40.0
+  resolution: "@sentry/core@npm:8.40.0"
+  dependencies:
+    "@sentry/types": "npm:8.40.0"
+  checksum: 10/450e2d35143a7918e1a5b4978c218df0f59ef10bd1b28fc92d1cbb491a0bebf28b2a1e8609361bd2070c9054c5e58d535de53cf3e3a46ecc75cf2c0e8a488aeb
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:8.41.0":
+  version: 8.41.0
+  resolution: "@sentry/core@npm:8.41.0"
+  dependencies:
+    "@sentry/types": "npm:8.41.0"
+  checksum: 10/76dceda22e6672c07462ad76b2b88d56cd3c677750cf6ee90e82f0e1b3826177f3c9f203dfed16dfee628eed8afaecb4b61d23942841604be310d53b84fbc11b
+  languageName: node
+  linkType: hard
+
+"@sentry/types@npm:8.40.0, @sentry/types@npm:^8.37.1":
+  version: 8.40.0
+  resolution: "@sentry/types@npm:8.40.0"
+  checksum: 10/6fba146cbd9bc89a16d0fcd8cb01e441e9720f8a72bb390038bbf25b1c2feeb7b18de437b755a0e70bca113d66357771055b695305a8923527fba89e096ed931
+  languageName: node
+  linkType: hard
+
+"@sentry/types@npm:8.41.0":
+  version: 8.41.0
+  resolution: "@sentry/types@npm:8.41.0"
+  checksum: 10/50e1a938be11f8f6f1951617d7e0fe55b1ea55c3b2beceed43f928d3b669adb58166a4e4a5dcd5282883d4f20b2b8d3283df506b42076714d91d0563a49abea6
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
@@ -2051,6 +2195,7 @@ __metadata:
   dependencies:
     "@seed-design/design-token": "npm:^1.0.3"
     "@seed-design/stylesheet": "npm:^1.0.4"
+    "@sentry/browser": "npm:^8.41.0"
     "@stackflow/compat-await-push": "npm:^1.1.13"
     "@stackflow/config": "npm:^1.2.0"
     "@stackflow/core": "npm:^1.1.0"
@@ -2158,6 +2303,7 @@ __metadata:
   dependencies:
     "@biomejs/biome": "npm:^1.8.3"
     "@changesets/cli": "npm:^2.27.7"
+    "@sentry/browser": "npm:^8.41.0"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.14.9"
     "@types/react": "npm:^18.3.3"
@@ -2339,6 +2485,20 @@ __metadata:
     "@stackflow/react": ^1.3.2-canary.0
     "@types/react": ">=16.8.0"
     react: ">=16.8.0"
+  languageName: unknown
+  linkType: soft
+
+"@stackflow/plugin-sentry@workspace:extensions/plugin-sentry":
+  version: 0.0.0-use.local
+  resolution: "@stackflow/plugin-sentry@workspace:extensions/plugin-sentry"
+  dependencies:
+    "@sentry/browser": "npm:^8.37.1"
+    "@sentry/core": "npm:^8.37.1"
+    "@sentry/types": "npm:^8.37.1"
+    "@stackflow/core": "npm:^1.1.0"
+    "@stackflow/esbuild-config": "npm:^1.0.3"
+    esbuild: "npm:^0.23.0"
+    typescript: "npm:^5.5.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### plugin-sentry (Issue from #520)

Stackflow has a unique screen handling with "Activity." 
Currently, Sentry doesn't support tracing for this mechanism, 
so we had to create own plugin.

this pr contains  a basic functional plugin that works for:

- Tracing page load events
- Tracing activity changes (push, pop, replace)

### How I Tested It: