### PR TITLE
chore(stackflow/core): Type inference friendly `divideBy`

### DIFF
--- a/.changeset/four-colts-nail.md
+++ b/.changeset/four-colts-nail.md
@@ -2,4 +2,4 @@
 "@stackflow/core": patch
 ---
 
-Type inference friendly `divideBy`
+Made `divideBy` to be friendly to type inference.

--- a/.changeset/four-colts-nail.md
+++ b/.changeset/four-colts-nail.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/core": patch
+---
+
+Type inference friendly `divideBy`

--- a/core/src/makeCoreStore.ts
+++ b/core/src/makeCoreStore.ts
@@ -52,7 +52,7 @@ export function makeCoreStore(options: MakeCoreStoreOptions): CoreStore {
 
   const [initialPushedEventsByOption, initialRemainingEvents] = divideBy(
     options.initialEvents,
-    (e: DomainEvent): e is PushedEvent | StepPushedEvent => e.name === "Pushed" || e.name === "StepPushed",
+    (e): e is PushedEvent | StepPushedEvent => e.name === "Pushed" || e.name === "StepPushed",
   );
 
   const initialPushedEvents = pluginInstances.reduce(

--- a/core/src/makeCoreStore.ts
+++ b/core/src/makeCoreStore.ts
@@ -52,7 +52,7 @@ export function makeCoreStore(options: MakeCoreStoreOptions): CoreStore {
 
   const [initialPushedEventsByOption, initialRemainingEvents] = divideBy(
     options.initialEvents,
-    (e): e is PushedEvent | StepPushedEvent => e.name === "Pushed" || e.name === "StepPushed",
+    (e) => e.name === "Pushed" || e.name === "StepPushed",
   );
 
   const initialPushedEvents = pluginInstances.reduce(

--- a/core/src/makeCoreStore.ts
+++ b/core/src/makeCoreStore.ts
@@ -52,7 +52,7 @@ export function makeCoreStore(options: MakeCoreStoreOptions): CoreStore {
 
   const [initialPushedEventsByOption, initialRemainingEvents] = divideBy(
     options.initialEvents,
-    (e) => e.name === "Pushed" || e.name === "StepPushed",
+    (e: DomainEvent): e is PushedEvent | StepPushedEvent => e.name === "Pushed" || e.name === "StepPushed",
   );
 
   const initialPushedEvents = pluginInstances.reduce(
@@ -61,7 +61,7 @@ export function makeCoreStore(options: MakeCoreStoreOptions): CoreStore {
         initialEvents,
         initialContext: options.initialContext ?? {},
       }) ?? initialEvents,
-    initialPushedEventsByOption as (PushedEvent | StepPushedEvent)[],
+    initialPushedEventsByOption,
   );
 
   const isInitialActivityIgnored =

--- a/core/src/utils/divideBy.ts
+++ b/core/src/utils/divideBy.ts
@@ -1,8 +1,8 @@
-export const divideBy = <T>(
+export const divideBy = <T, U extends T>(
   arr: T[],
-  predicate: (t: T) => boolean,
-): [T[], T[]] => {
-  const satisfied: T[] = [];
+  predicate: (t: T) => t is U,
+): [U[], T[]] => {
+  const satisfied: U[] = [];
   const unsatisfied: T[] = [];
 
   arr.forEach((element) => {


### PR DESCRIPTION
# Description

Current type definition of `divideBy` has loose typing that makes programmer to use unnecessary assertions or additional checks. I've changed the type so that we can remove uncomfortable assertions.

# Checkpoints

- Since there is no 'negated type' in typescript, Unsatisfied cases remains to be value of the type `T`. ([`Exclude` is not an option](https://github.com/microsoft/TypeScript/wiki/FAQ#exclude-isnt-type-negation))
- `divideBy`'s being parameterized by two unrelated types was considered but eventually excluded since it does not work well with the type checker's design. (Due to subtyping, it is possible for the type checker to infer an variable as too general type)