### PR TITLE
feat(react): make 'the update function pattern' available in step creation(push/replace)

### DIFF
--- a/.changeset/plenty-stingrays-knock.md
+++ b/.changeset/plenty-stingrays-knock.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/react": minor
+---
+
+The 'update functions' pattern for step push and replace actions is implemented.

--- a/integrations/react/src/__internal__/activity/findLatestActiveActivity.ts
+++ b/integrations/react/src/__internal__/activity/findLatestActiveActivity.ts
@@ -1,0 +1,15 @@
+import type { Activity } from "@stackflow/core";
+
+function isActivityNotExited(activity: Activity) {
+  return !activity.exitedBy;
+}
+
+function compareActivitiesByEventDate(a1: Activity, a2: Activity) {
+  return a2.enteredBy.eventDate - a1.enteredBy.eventDate;
+}
+
+export function findLatestActiveActivity(activities: Activity[]) {
+  return activities
+    .filter(isActivityNotExited)
+    .sort(compareActivitiesByEventDate)[0];
+}

--- a/integrations/react/src/future/StepActions.ts
+++ b/integrations/react/src/future/StepActions.ts
@@ -1,12 +1,12 @@
 export type StepActions<ActivityParams> = {
   pushStep: (
-    params: ActivityParams,
+    params: ActivityParams | ((prevParams: ActivityParams) => ActivityParams),
     options?: {
       targetActivityId?: string;
     },
   ) => void;
   replaceStep: (
-    params: ActivityParams,
+    params: ActivityParams | ((prevParams: ActivityParams) => ActivityParams),
     options?: {
       targetActivityId?: string;
     },

--- a/integrations/react/src/future/makeStepActions.ts
+++ b/integrations/react/src/future/makeStepActions.ts
@@ -10,16 +10,8 @@ export function makeStepActions(
   return {
     pushStep(stepParams, options) {
       const coreActions = getCoreActions();
-
-      if (!coreActions) {
-        throw new Error(
-          "Cannot perform any action since no implementation is available.",
-        );
-      }
-
-      const targetActivity = findTargetActivity(
-        coreActions.getStack().activities,
-      );
+      const activities = coreActions?.getStack().activities;
+      const targetActivity = activities && findTargetActivity(activities);
 
       if (!targetActivity) {
         throw new Error(
@@ -41,16 +33,8 @@ export function makeStepActions(
     },
     replaceStep(stepParams, options) {
       const coreActions = getCoreActions();
-
-      if (!coreActions) {
-        throw new Error(
-          "Cannot perform any action since no implementation is available.",
-        );
-      }
-
-      const targetActivity = findTargetActivity(
-        coreActions.getStack().activities,
-      );
+      const activities = coreActions?.getStack().activities;
+      const targetActivity = activities && findTargetActivity(activities);
 
       if (!targetActivity) {
         throw new Error(

--- a/integrations/react/src/future/makeStepActions.ts
+++ b/integrations/react/src/future/makeStepActions.ts
@@ -1,17 +1,17 @@
 import type { ActivityBaseParams } from "@stackflow/config";
-import type { Activity, CoreStore } from "@stackflow/core";
+import type { CoreStore } from "@stackflow/core";
+import { findLatestActiveActivity } from "__internal__/activity/findLatestActiveActivity";
 import { makeStepId } from "../__internal__/activity";
 import type { StepActions } from "./StepActions";
 
 export function makeStepActions(
   getCoreActions: () => CoreStore["actions"] | undefined,
-  findTargetActivity: (activity: Activity[]) => Activity | undefined,
 ): StepActions<ActivityBaseParams> {
   return {
     pushStep(stepParams, options) {
       const coreActions = getCoreActions();
       const activities = coreActions?.getStack().activities;
-      const targetActivity = activities && findTargetActivity(activities);
+      const targetActivity = activities && findLatestActiveActivity(activities);
 
       if (!targetActivity) {
         throw new Error(
@@ -34,7 +34,7 @@ export function makeStepActions(
     replaceStep(stepParams, options) {
       const coreActions = getCoreActions();
       const activities = coreActions?.getStack().activities;
-      const targetActivity = activities && findTargetActivity(activities);
+      const targetActivity = activities && findLatestActiveActivity(activities);
 
       if (!targetActivity) {
         throw new Error(

--- a/integrations/react/src/future/makeStepActions.ts
+++ b/integrations/react/src/future/makeStepActions.ts
@@ -1,7 +1,7 @@
 import type { ActivityBaseParams } from "@stackflow/config";
 import type { CoreStore } from "@stackflow/core";
-import { findLatestActiveActivity } from "__internal__/activity/findLatestActiveActivity";
 import { makeStepId } from "../__internal__/activity";
+import { findLatestActiveActivity } from "../__internal__/activity/findLatestActiveActivity";
 import type { StepActions } from "./StepActions";
 
 export function makeStepActions(

--- a/integrations/react/src/future/makeStepActions.ts
+++ b/integrations/react/src/future/makeStepActions.ts
@@ -1,27 +1,72 @@
 import type { ActivityBaseParams } from "@stackflow/config";
-import type { CoreStore } from "@stackflow/core";
+import type { Activity, CoreStore } from "@stackflow/core";
 import { makeStepId } from "../__internal__/activity";
 import type { StepActions } from "./StepActions";
 
 export function makeStepActions(
   getCoreActions: () => CoreStore["actions"] | undefined,
+  findTargetActivity: (activity: Activity[]) => Activity | undefined,
 ): StepActions<ActivityBaseParams> {
   return {
     pushStep(stepParams, options) {
+      const coreActions = getCoreActions();
+
+      if (!coreActions) {
+        throw new Error(
+          "Cannot perform any action since no implementation is available.",
+        );
+      }
+
+      const targetActivity = findTargetActivity(
+        coreActions.getStack().activities,
+      );
+
+      if (!targetActivity) {
+        throw new Error(
+          "Cannot push a step. The target activity is not found.",
+        );
+      }
+
+      const nextParams =
+        typeof stepParams === "function"
+          ? stepParams(targetActivity.params)
+          : stepParams;
       const stepId = makeStepId();
 
-      getCoreActions()?.stepPush({
+      coreActions.stepPush({
         stepId,
-        stepParams,
+        stepParams: nextParams,
         targetActivityId: options?.targetActivityId,
       });
     },
     replaceStep(stepParams, options) {
+      const coreActions = getCoreActions();
+
+      if (!coreActions) {
+        throw new Error(
+          "Cannot perform any action since no implementation is available.",
+        );
+      }
+
+      const targetActivity = findTargetActivity(
+        coreActions.getStack().activities,
+      );
+
+      if (!targetActivity) {
+        throw new Error(
+          "Cannot push a step. The target activity is not found.",
+        );
+      }
+
+      const nextParams =
+        typeof stepParams === "function"
+          ? stepParams(targetActivity.params)
+          : stepParams;
       const stepId = makeStepId();
 
-      getCoreActions()?.stepReplace({
+      coreActions.stepReplace({
         stepId,
-        stepParams,
+        stepParams: nextParams,
         targetActivityId: options?.targetActivityId,
       });
     },

--- a/integrations/react/src/future/stackflow.tsx
+++ b/integrations/react/src/future/stackflow.tsx
@@ -10,6 +10,7 @@ import {
   makeCoreStore,
   makeEvent,
 } from "@stackflow/core";
+import { findLatestActiveActivity } from "__internal__/activity/findLatestActiveActivity";
 import React, { useMemo } from "react";
 import MainRenderer from "../__internal__/MainRenderer";
 import { makeActivityId } from "../__internal__/activity";
@@ -174,6 +175,9 @@ export function stackflow<
   return {
     Stack,
     actions: makeActions(() => getCoreStore()?.actions),
-    stepActions: makeStepActions(() => getCoreStore()?.actions),
+    stepActions: makeStepActions(
+      () => getCoreStore()?.actions,
+      findLatestActiveActivity,
+    ),
   };
 }

--- a/integrations/react/src/future/stackflow.tsx
+++ b/integrations/react/src/future/stackflow.tsx
@@ -10,10 +10,10 @@ import {
   makeCoreStore,
   makeEvent,
 } from "@stackflow/core";
-import { findLatestActiveActivity } from "__internal__/activity/findLatestActiveActivity";
 import React, { useMemo } from "react";
 import MainRenderer from "../__internal__/MainRenderer";
 import { makeActivityId } from "../__internal__/activity";
+import { findLatestActiveActivity } from "../__internal__/activity/findLatestActiveActivity";
 import { CoreProvider } from "../__internal__/core";
 import { PluginsProvider } from "../__internal__/plugins";
 import { isBrowser, makeRef } from "../__internal__/utils";

--- a/integrations/react/src/future/stackflow.tsx
+++ b/integrations/react/src/future/stackflow.tsx
@@ -175,9 +175,6 @@ export function stackflow<
   return {
     Stack,
     actions: makeActions(() => getCoreStore()?.actions),
-    stepActions: makeStepActions(
-      () => getCoreStore()?.actions,
-      findLatestActiveActivity,
-    ),
+    stepActions: makeStepActions(() => getCoreStore()?.actions),
   };
 }

--- a/integrations/react/src/future/useStepFlow.ts
+++ b/integrations/react/src/future/useStepFlow.ts
@@ -2,8 +2,8 @@ import type {
   InferActivityParams,
   RegisteredActivityName,
 } from "@stackflow/config";
-import { ActivityContext } from "__internal__/activity";
 import { useContext } from "react";
+import { ActivityContext } from "../__internal__/activity";
 import { useCoreActions } from "../__internal__/core";
 import type { StepActions } from "./StepActions";
 import { makeStepActions } from "./makeStepActions";

--- a/integrations/react/src/future/useStepFlow.ts
+++ b/integrations/react/src/future/useStepFlow.ts
@@ -2,8 +2,6 @@ import type {
   InferActivityParams,
   RegisteredActivityName,
 } from "@stackflow/config";
-import { useContext } from "react";
-import { ActivityContext } from "../__internal__/activity";
 import { useCoreActions } from "../__internal__/core";
 import type { StepActions } from "./StepActions";
 import { makeStepActions } from "./makeStepActions";
@@ -12,7 +10,6 @@ export function useStepFlow<ActivityName extends RegisteredActivityName>(
   activityName: ActivityName,
 ): StepActions<InferActivityParams<ActivityName>> {
   const coreActions = useCoreActions();
-  const { id } = useContext(ActivityContext);
 
   return makeStepActions(() => coreActions);
 }

--- a/integrations/react/src/future/useStepFlow.ts
+++ b/integrations/react/src/future/useStepFlow.ts
@@ -14,8 +14,5 @@ export function useStepFlow<ActivityName extends RegisteredActivityName>(
   const coreActions = useCoreActions();
   const { id } = useContext(ActivityContext);
 
-  return makeStepActions(
-    () => coreActions,
-    (activities) => activities.find((activity) => activity.id === id),
-  );
+  return makeStepActions(() => coreActions);
 }

--- a/integrations/react/src/future/useStepFlow.ts
+++ b/integrations/react/src/future/useStepFlow.ts
@@ -2,6 +2,8 @@ import type {
   InferActivityParams,
   RegisteredActivityName,
 } from "@stackflow/config";
+import { ActivityContext } from "__internal__/activity";
+import { useContext } from "react";
 import { useCoreActions } from "../__internal__/core";
 import type { StepActions } from "./StepActions";
 import { makeStepActions } from "./makeStepActions";
@@ -10,5 +12,10 @@ export function useStepFlow<ActivityName extends RegisteredActivityName>(
   activityName: ActivityName,
 ): StepActions<InferActivityParams<ActivityName>> {
   const coreActions = useCoreActions();
-  return makeStepActions(() => coreActions);
+  const { id } = useContext(ActivityContext);
+
+  return makeStepActions(
+    () => coreActions,
+    (activities) => activities.find((activity) => activity.id === id),
+  );
 }

--- a/integrations/react/src/stable/stackflow.tsx
+++ b/integrations/react/src/stable/stackflow.tsx
@@ -349,7 +349,7 @@ export function stackflow<T extends BaseActivities>(
           activities && findLatestActiveActivity(activities);
 
         if (!targetActivity)
-          throw new Error("There is no activity to push step");
+          throw new Error("There is no activity to push a step");
 
         const previousParams = targetActivity.params;
         const nextParams =
@@ -362,11 +362,21 @@ export function stackflow<T extends BaseActivities>(
         });
       },
       stepReplace(params) {
+        const activities = getCoreStore()?.actions.getStack().activities;
+        const targetActivity =
+          activities && findLatestActiveActivity(activities);
+
+        if (!targetActivity)
+          throw new Error("There is no activity to replace a step");
+
+        const previousParams = targetActivity.params;
+        const nextParams =
+          typeof params === "function" ? params(previousParams) : params;
         const stepId = makeStepId();
 
         return getCoreStore()?.actions.stepReplace({
           stepId,
-          stepParams: params,
+          stepParams: nextParams,
         });
       },
       stepPop() {

--- a/integrations/react/src/stable/stackflow.tsx
+++ b/integrations/react/src/stable/stackflow.tsx
@@ -345,38 +345,34 @@ export function stackflow<T extends BaseActivities>(
       },
       stepPush(params) {
         const activities = getCoreStore()?.actions.getStack().activities;
-        const targetActivity =
-          activities && findLatestActiveActivity(activities);
 
-        if (!targetActivity)
+        if (!activities || activities.length === 0)
           throw new Error("There is no activity to push a step");
 
-        const previousParams = targetActivity.params;
-        const nextParams =
-          typeof params === "function" ? params(previousParams) : params;
+        const targetActivity = findLatestActiveActivity(activities);
+        const stepParams =
+          typeof params === "function" ? params(targetActivity.params) : params;
         const stepId = makeStepId();
 
         return getCoreStore()?.actions.stepPush({
           stepId,
-          stepParams: nextParams,
+          stepParams,
         });
       },
       stepReplace(params) {
         const activities = getCoreStore()?.actions.getStack().activities;
-        const targetActivity =
-          activities && findLatestActiveActivity(activities);
 
-        if (!targetActivity)
-          throw new Error("There is no activity to replace a step");
+        if (!activities || activities.length === 0)
+          throw new Error("There is no activity to push a step");
 
-        const previousParams = targetActivity.params;
-        const nextParams =
-          typeof params === "function" ? params(previousParams) : params;
+        const targetActivity = findLatestActiveActivity(activities);
+        const stepParams =
+          typeof params === "function" ? params(targetActivity.params) : params;
         const stepId = makeStepId();
 
         return getCoreStore()?.actions.stepReplace({
           stepId,
-          stepParams: nextParams,
+          stepParams,
         });
       },
       stepPop() {

--- a/integrations/react/src/stable/stackflow.tsx
+++ b/integrations/react/src/stable/stackflow.tsx
@@ -7,11 +7,11 @@ import type {
 import { makeCoreStore, makeEvent } from "@stackflow/core";
 import { memo, useMemo } from "react";
 
-import { findLatestActiveActivity } from "__internal__/activity/findLatestActiveActivity";
 import type { ActivityComponentType } from "../__internal__/ActivityComponentType";
 import MainRenderer from "../__internal__/MainRenderer";
 import type { StackflowReactPlugin } from "../__internal__/StackflowReactPlugin";
 import { makeActivityId, makeStepId } from "../__internal__/activity";
+import { findLatestActiveActivity } from "../__internal__/activity/findLatestActiveActivity";
 import { CoreProvider } from "../__internal__/core";
 import { PluginsProvider } from "../__internal__/plugins";
 import { isBrowser, makeRef } from "../__internal__/utils";

--- a/integrations/react/src/stable/stackflow.tsx
+++ b/integrations/react/src/stable/stackflow.tsx
@@ -18,10 +18,7 @@ import { isBrowser, makeRef } from "../__internal__/utils";
 import type { BaseActivities } from "./BaseActivities";
 import type { UseActionsOutputType } from "./useActions";
 import { useActions } from "./useActions";
-import type {
-  UseStepActions,
-  UseStepActionsOutputType,
-} from "./useStepActions";
+import type { UseStepActionsOutputType } from "./useStepActions";
 import { useStepActions } from "./useStepActions";
 
 function parseActionOptions(options?: { animate?: boolean }) {
@@ -90,7 +87,15 @@ export type StackflowOutput<T extends BaseActivities> = {
   /**
    * Created `useStepFlow()` hooks
    */
-  useStepFlow: UseStepActions<T>;
+  useStepFlow: <K extends Extract<keyof T, string>>(
+    activityName: K,
+  ) => UseStepActionsOutputType<
+    T[K] extends
+      | ActivityComponentType<infer U>
+      | { component: ActivityComponentType<infer U> }
+      ? U
+      : {}
+  >;
 
   /**
    * Add activity imperatively

--- a/integrations/react/src/stable/useStepActions.ts
+++ b/integrations/react/src/stable/useStepActions.ts
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
 
-import type { ActivityComponentType } from "../__internal__/ActivityComponentType";
 import { makeStepId } from "../__internal__/activity";
 import { useCoreActions } from "../__internal__/core";
 import { useTransition } from "../__internal__/shims";
-import type { BaseActivities } from "./BaseActivities";
 
 export type UseStepActionsOutputType<P> = {
   pending: boolean;

--- a/integrations/react/src/stable/useStepActions.ts
+++ b/integrations/react/src/stable/useStepActions.ts
@@ -28,7 +28,7 @@ export const useStepActions = <
   const { id } = useActivity();
   const [pending] = useTransition();
   const resolveNextParams = useCallback(
-    (activityId: string, params: P | ((previousParams: P) => P)) => {
+    (activityId: string, updator: (previousParams: P) => P): P => {
       const targetActivity = coreActions
         ?.getStack()
         .activities.find(({ id }) => id === activityId);
@@ -37,7 +37,7 @@ export const useStepActions = <
 
       const previousParams = targetActivity.params as P;
 
-      return typeof params === "function" ? params(previousParams) : params;
+      return updator(previousParams);
     },
     [coreActions],
   );
@@ -47,23 +47,29 @@ export const useStepActions = <
       pending,
       stepPush(params, options) {
         const targetActivityId = options?.targetActivityId ?? id;
-        const nextParams = resolveNextParams(targetActivityId, params);
+        const stepParams =
+          typeof params === "function"
+            ? resolveNextParams(targetActivityId, params)
+            : params;
         const stepId = makeStepId();
 
         coreActions?.stepPush({
           stepId,
-          stepParams: nextParams,
+          stepParams,
           targetActivityId: options?.targetActivityId,
         });
       },
       stepReplace(params, options) {
         const targetActivityId = options?.targetActivityId ?? id;
-        const nextParams = resolveNextParams(targetActivityId, params);
+        const stepParams =
+          typeof params === "function"
+            ? resolveNextParams(targetActivityId, params)
+            : params;
         const stepId = makeStepId();
 
         coreActions?.stepReplace({
           stepId,
-          stepParams: nextParams,
+          stepParams,
           targetActivityId: options?.targetActivityId,
         });
       },

--- a/integrations/react/src/stable/useStepActions.ts
+++ b/integrations/react/src/stable/useStepActions.ts
@@ -23,19 +23,9 @@ export type UseStepActionsOutputType<P> = {
   stepPop: (options?: { targetActivityId?: string }) => void;
 };
 
-export type UseStepActions<T extends BaseActivities = {}> = <
-  K extends Extract<keyof T, string>,
->(
-  activityName: K,
-) => UseStepActionsOutputType<
-  T[K] extends
-    | ActivityComponentType<infer U>
-    | { component: ActivityComponentType<infer U> }
-    ? U
-    : {}
->;
-
-export const useStepActions: UseStepActions = () => {
+export const useStepActions = <
+  P extends Record<string, string | undefined>,
+>(): UseStepActionsOutputType<P> => {
   const coreActions = useCoreActions();
   const [pending] = useTransition();
 

--- a/integrations/react/src/stable/useStepActions.ts
+++ b/integrations/react/src/stable/useStepActions.ts
@@ -27,29 +27,22 @@ export const useStepActions = <
   const coreActions = useCoreActions();
   const { id } = useActivity();
   const [pending] = useTransition();
-  const resolveNextParams = useCallback(
-    (activityId: string, updator: (previousParams: P) => P): P => {
-      const targetActivity = coreActions
-        ?.getStack()
-        .activities.find(({ id }) => id === activityId);
-
-      if (!targetActivity) throw new Error("The target activity is not found.");
-
-      const previousParams = targetActivity.params as P;
-
-      return updator(previousParams);
-    },
-    [coreActions],
-  );
 
   return useMemo(
     () => ({
       pending,
       stepPush(params, options) {
         const targetActivityId = options?.targetActivityId ?? id;
+        const targetActivity = coreActions
+          ?.getStack()
+          .activities.find(({ id }) => id === targetActivityId);
+
+        if (!targetActivity)
+          throw new Error("The target activity is not found.");
+
         const stepParams =
           typeof params === "function"
-            ? resolveNextParams(targetActivityId, params)
+            ? params(targetActivity.params as P)
             : params;
         const stepId = makeStepId();
 
@@ -61,9 +54,16 @@ export const useStepActions = <
       },
       stepReplace(params, options) {
         const targetActivityId = options?.targetActivityId ?? id;
+        const targetActivity = coreActions
+          ?.getStack()
+          .activities.find(({ id }) => id === targetActivityId);
+
+        if (!targetActivity)
+          throw new Error("The target activity is not found.");
+
         const stepParams =
           typeof params === "function"
-            ? resolveNextParams(targetActivityId, params)
+            ? params(targetActivity.params as P)
             : params;
         const stepId = makeStepId();
 
@@ -83,6 +83,7 @@ export const useStepActions = <
       coreActions?.stepPush,
       coreActions?.stepReplace,
       coreActions?.stepPop,
+      coreActions?.getStack,
       pending,
       id,
     ],

--- a/integrations/react/src/stable/useStepActions.ts
+++ b/integrations/react/src/stable/useStepActions.ts
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
 
 import type { Activity } from "@stackflow/core";
-import { findLatestActiveActivity } from "__internal__/activity/findLatestActiveActivity";
 import { makeStepId } from "../__internal__/activity";
+import { findLatestActiveActivity } from "../__internal__/activity/findLatestActiveActivity";
 import { useCoreActions } from "../__internal__/core";
 import { useTransition } from "../__internal__/shims";
 


### PR DESCRIPTION
As current implementation resolves target activity of a given step creation event(push or replace) to latest active activity(lastly entered activity), update functions are given up-to-date params of them.