### PR TITLE
feat(plugin-basic-ui): Add option to configure `background-image`

### DIFF
--- a/.changeset/poor-mice-join.md
+++ b/.changeset/poor-mice-join.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-basic-ui": minor
+---
+
+To support various background designs, enable users to configure the background-image option in AppScreen, AppBar, BottomSheet and Modal.

--- a/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
@@ -7,6 +7,7 @@ import { recipe } from "@vanilla-extract/recipes";
 
 const GLOBAL_VARS = {
   backgroundColor: "background-color",
+  backgroundImage: "background-image",
   dimBackgroundColor: "dim-background-color",
   transitionDuration: "transition-duration",
   computedTransitionDuration: "computed-transition-duration",
@@ -45,6 +46,7 @@ export type GlobalVars = typeof GLOBAL_VARS;
 
 const androidValues: GlobalVars = {
   backgroundColor: "#fff",
+  backgroundImage: "none",
   dimBackgroundColor: "rgba(0, 0, 0, 0.15)",
   transitionDuration: "0s",
   computedTransitionDuration: "0s",

--- a/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
@@ -25,6 +25,9 @@ const GLOBAL_VARS = {
     backgroundColor: "app-bar-background-color",
     backgroundColorTransitionDuration:
       "app-bar-background-color-transition-duration",
+    backgroundImage: "app-bar-background-image",
+    backgroundImageTransitionDuration:
+      "app-bar-background-image-transition-duration",
     overflow: "app-bar-overflow",
     minSafeAreaInsetTop: "app-bar-min-safe-area-inset-top",
   },
@@ -63,6 +66,8 @@ const androidValues: GlobalVars = {
     textColorTransitionDuration: "0s",
     backgroundColor: "#fff",
     backgroundColorTransitionDuration: "0s",
+    backgroundImage: "none",
+    backgroundImageTransitionDuration: "0s",
     overflow: "hidden",
     minSafeAreaInsetTop: "0px",
   },

--- a/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
@@ -49,7 +49,7 @@ export type GlobalVars = typeof GLOBAL_VARS;
 
 const androidValues: GlobalVars = {
   backgroundColor: "#fff",
-  backgroundImage: "none",
+  backgroundImage: "unset",
   dimBackgroundColor: "rgba(0, 0, 0, 0.15)",
   transitionDuration: "0s",
   computedTransitionDuration: "0s",
@@ -66,7 +66,7 @@ const androidValues: GlobalVars = {
     textColorTransitionDuration: "0s",
     backgroundColor: "#fff",
     backgroundColorTransitionDuration: "0s",
-    backgroundImage: "none",
+    backgroundImage: "unsets",
     backgroundImageTransitionDuration: "0s",
     overflow: "hidden",
     minSafeAreaInsetTop: "0px",

--- a/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
@@ -66,7 +66,7 @@ const androidValues: GlobalVars = {
     textColorTransitionDuration: "0s",
     backgroundColor: "#fff",
     backgroundColorTransitionDuration: "0s",
-    backgroundImage: "unsets",
+    backgroundImage: "unset",
     backgroundImageTransitionDuration: "0s",
     overflow: "hidden",
     minSafeAreaInsetTop: "0px",

--- a/extensions/plugin-basic-ui/src/basicUIPlugin.tsx
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.tsx
@@ -68,6 +68,7 @@ export const basicUIPlugin: (
           style={assignInlineVars(
             compactMap({
               [css.globalVars.backgroundColor]: _options.backgroundColor,
+              [css.globalVars.backgroundImage]: _options.backgroundImage,
               [css.globalVars.dimBackgroundColor]: _options.dimBackgroundColor,
               [css.globalVars.transitionDuration]:
                 `${stack.transitionDuration}ms`,

--- a/extensions/plugin-basic-ui/src/components/AppBar.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppBar.css.ts
@@ -25,8 +25,8 @@ function transitions(args: { [cssFieldName: string]: string }) {
 }
 const appBarCommonTransition = {
   "background-color": globalVars.appBar.backgroundColorTransitionDuration,
-  "box-shadow": globalVars.appBar.borderColorTransitionDuration,
   "background-image": globalVars.appBar.backgroundImageTransitionDuration,
+  "box-shadow": globalVars.appBar.borderColorTransitionDuration,
 };
 
 export const appBar = recipe({

--- a/extensions/plugin-basic-ui/src/components/AppBar.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppBar.css.ts
@@ -26,6 +26,7 @@ function transitions(args: { [cssFieldName: string]: string }) {
 const appBarCommonTransition = {
   "background-color": globalVars.appBar.backgroundColorTransitionDuration,
   "box-shadow": globalVars.appBar.borderColorTransitionDuration,
+  "background-image": globalVars.appBar.backgroundImageTransitionDuration,
 };
 
 export const appBar = recipe({
@@ -37,6 +38,7 @@ export const appBar = recipe({
     appBarOverflow,
     {
       backgroundColor: globalVars.appBar.backgroundColor,
+      backgroundImage: globalVars.appBar.backgroundImage,
       zIndex: vars.zIndexes.appBar,
       transition: transitions(appBarCommonTransition),
       selectors: {

--- a/extensions/plugin-basic-ui/src/components/AppBar.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppBar.tsx
@@ -30,6 +30,8 @@ type AppBarProps = Partial<
     | "textColorTransitionDuration"
     | "backgroundColor"
     | "backgroundColorTransitionDuration"
+    | "backgroundImage"
+    | "backgroundImageTransitionDuration"
   >
 > & {
   title?: React.ReactNode;
@@ -83,6 +85,8 @@ const AppBar = forwardRef<HTMLDivElement, AppBarProps>(
       overflow,
       backgroundColor,
       backgroundColorTransitionDuration,
+      backgroundImage,
+      backgroundImageTransitionDuration,
       onTopClick,
     },
     ref,
@@ -293,6 +297,10 @@ const AppBar = forwardRef<HTMLDivElement, AppBarProps>(
               backgroundColor || globalVars.backgroundColor,
             [globalVars.appBar.backgroundColorTransitionDuration]:
               backgroundColorTransitionDuration,
+            [globalVars.appBar.backgroundImage]:
+              backgroundImage || globalVars.backgroundImage,
+            [globalVars.appBar.backgroundImageTransitionDuration]:
+              backgroundImageTransitionDuration,
             [appScreenCss.vars.appBar.center.mainWidth]: `${maxWidth}px`,
           }),
         )}

--- a/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.css.ts
@@ -26,6 +26,7 @@ const dimBackgroundColor = style({
 
 export const background = style({
   backgroundColor: globalVars.backgroundColor,
+  backgroundImage: globalVars.backgroundImage,
 });
 
 export const allTransitions = style({

--- a/extensions/plugin-basic-ui/src/components/AppScreen.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.tsx
@@ -38,7 +38,7 @@ export function useAppScreen() {
 }
 
 export type AppScreenProps = Partial<
-  Pick<GlobalVars, "backgroundColor" | "dimBackgroundColor" | "backgroundImage">
+  Pick<GlobalVars, "backgroundColor" | "backgroundImage" | "dimBackgroundColor">
 > & {
   appBar?: Omit<
     PropOf<typeof AppBar>,
@@ -51,8 +51,8 @@ export type AppScreenProps = Partial<
 };
 const AppScreen: React.FC<AppScreenProps> = ({
   backgroundColor,
-  dimBackgroundColor,
   backgroundImage,
+  dimBackgroundColor,
   appBar,
   preventSwipeBack,
   CUPERTINO_ONLY_modalPresentationStyle,
@@ -225,8 +225,8 @@ const AppScreen: React.FC<AppScreenProps> = ({
         style={assignInlineVars(
           compactMap({
             [globalVars.backgroundColor]: backgroundColor,
-            [globalVars.dimBackgroundColor]: dimBackgroundColor,
             [globalVars.backgroundImage]: backgroundImage,
+            [globalVars.dimBackgroundColor]: dimBackgroundColor,
             [globalVars.appBar.height]: appBar?.height,
             [globalVars.appBar.heightTransitionDuration]:
               appBar?.heightTransitionDuration,

--- a/extensions/plugin-basic-ui/src/components/AppScreen.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.tsx
@@ -38,7 +38,7 @@ export function useAppScreen() {
 }
 
 export type AppScreenProps = Partial<
-  Pick<GlobalVars, "backgroundColor" | "dimBackgroundColor">
+  Pick<GlobalVars, "backgroundColor" | "dimBackgroundColor" | "backgroundImage">
 > & {
   appBar?: Omit<
     PropOf<typeof AppBar>,
@@ -52,6 +52,7 @@ export type AppScreenProps = Partial<
 const AppScreen: React.FC<AppScreenProps> = ({
   backgroundColor,
   dimBackgroundColor,
+  backgroundImage,
   appBar,
   preventSwipeBack,
   CUPERTINO_ONLY_modalPresentationStyle,
@@ -225,6 +226,7 @@ const AppScreen: React.FC<AppScreenProps> = ({
           compactMap({
             [globalVars.backgroundColor]: backgroundColor,
             [globalVars.dimBackgroundColor]: dimBackgroundColor,
+            [globalVars.backgroundImage]: backgroundImage,
             [globalVars.appBar.height]: appBar?.height,
             [globalVars.appBar.heightTransitionDuration]:
               appBar?.heightTransitionDuration,

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.css.ts
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.css.ts
@@ -60,6 +60,7 @@ export const paper = style([
   allTransitions,
   {
     backgroundColor: globalVars.backgroundColor,
+    backgroundImage: globalVars.backgroundImage,
     width: "100%",
     borderRadius: `${globalVars.bottomSheet.borderRadius} ${globalVars.bottomSheet.borderRadius} 0 0`,
     transform: "translate3d(0, 100%, 0)",

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
@@ -14,7 +14,7 @@ import { compactMap } from "../utils";
 import * as css from "./BottomSheet.css";
 
 export type BottomSheetProps = Partial<
-  Pick<GlobalVars, "backgroundColor" | "dimBackgroundColor" | "backgroundImage">
+  Pick<GlobalVars, "backgroundColor" | "backgroundImage" | "dimBackgroundColor">
 > &
   Partial<GlobalVars["bottomSheet"]> & {
     paperRef?: React.Ref<HTMLDivElement>;

--- a/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
+++ b/extensions/plugin-basic-ui/src/components/BottomSheet.tsx
@@ -14,7 +14,7 @@ import { compactMap } from "../utils";
 import * as css from "./BottomSheet.css";
 
 export type BottomSheetProps = Partial<
-  Pick<GlobalVars, "backgroundColor" | "dimBackgroundColor">
+  Pick<GlobalVars, "backgroundColor" | "dimBackgroundColor" | "backgroundImage">
 > &
   Partial<GlobalVars["bottomSheet"]> & {
     paperRef?: React.Ref<HTMLDivElement>;
@@ -24,6 +24,7 @@ export type BottomSheetProps = Partial<
 const BottomSheet: React.FC<BottomSheetProps> = ({
   borderRadius = "1rem",
   backgroundColor,
+  backgroundImage,
   dimBackgroundColor,
   paperRef,
   onOutsideClick,
@@ -82,6 +83,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
         compactMap({
           [globalVars.bottomSheet.borderRadius]: borderRadius,
           [globalVars.backgroundColor]: backgroundColor,
+          [globalVars.backgroundImage]: backgroundImage,
           [globalVars.dimBackgroundColor]: dimBackgroundColor,
           [css.vars.zIndexes.dim]: `${zIndexBase}`,
           [css.vars.zIndexes.paper]: `${zIndexPaper}`,

--- a/extensions/plugin-basic-ui/src/components/Modal.css.ts
+++ b/extensions/plugin-basic-ui/src/components/Modal.css.ts
@@ -61,6 +61,7 @@ export const paper = style([
   allTransitions,
   {
     backgroundColor: globalVars.backgroundColor,
+    backgroundImage: globalVars.backgroundImage,
     width: "100%",
     maxWidth: globalVars.modal.maxWidth,
     margin: "0 2.5rem",

--- a/extensions/plugin-basic-ui/src/components/Modal.tsx
+++ b/extensions/plugin-basic-ui/src/components/Modal.tsx
@@ -14,7 +14,7 @@ import { compactMap } from "../utils";
 import * as css from "./Modal.css";
 
 export type ModalProps = Partial<
-  Pick<GlobalVars, "backgroundColor" | "dimBackgroundColor">
+  Pick<GlobalVars, "backgroundColor" | "dimBackgroundColor" | "backgroundImage">
 > &
   Partial<GlobalVars["modal"]> & {
     onOutsideClick?: React.MouseEventHandler;
@@ -23,6 +23,7 @@ export type ModalProps = Partial<
 const Modal: React.FC<ModalProps> = ({
   backgroundColor,
   dimBackgroundColor,
+  backgroundImage,
   borderRadius = "1rem",
   maxWidth,
   onOutsideClick,
@@ -80,6 +81,7 @@ const Modal: React.FC<ModalProps> = ({
       style={assignInlineVars(
         compactMap({
           [globalVars.backgroundColor]: backgroundColor,
+          [globalVars.backgroundImage]: backgroundImage,
           [globalVars.dimBackgroundColor]: dimBackgroundColor,
           [globalVars.modal.borderRadius]: borderRadius,
           [globalVars.modal.maxWidth]: maxWidth,

--- a/extensions/plugin-basic-ui/src/components/Modal.tsx
+++ b/extensions/plugin-basic-ui/src/components/Modal.tsx
@@ -14,7 +14,7 @@ import { compactMap } from "../utils";
 import * as css from "./Modal.css";
 
 export type ModalProps = Partial<
-  Pick<GlobalVars, "backgroundColor" | "dimBackgroundColor" | "backgroundImage">
+  Pick<GlobalVars, "backgroundColor" | "backgroundImage" | "dimBackgroundColor">
 > &
   Partial<GlobalVars["modal"]> & {
     onOutsideClick?: React.MouseEventHandler;
@@ -22,8 +22,8 @@ export type ModalProps = Partial<
   };
 const Modal: React.FC<ModalProps> = ({
   backgroundColor,
-  dimBackgroundColor,
   backgroundImage,
+  dimBackgroundColor,
   borderRadius = "1rem",
   maxWidth,
   onOutsideClick,


### PR DESCRIPTION
To support various background designs, enable users to configure the `background-image` option in `AppScreen`, `AppBar`, `BottomSheet` and `Modal`.