### PR TITLE
fix(plugin-basic-ui,react-ui-core): prevent touch events while transitioning

### DIFF
--- a/.changeset/metal-pandas-dance.md
+++ b/.changeset/metal-pandas-dance.md
@@ -1,0 +1,6 @@
+---
+"@stackflow/plugin-basic-ui": patch
+"@stackflow/react-ui-core": patch
+---
+
+fix(plugin-basic-ui,react-ui-core): prevent touch events while transitioning

--- a/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
@@ -115,14 +115,5 @@ export const stackWrapper = recipe({
       android,
       cupertino,
     },
-    globalTransitionState: {
-      idle: {},
-      loading: {
-        // pointerEvents: "none",
-      },
-      paused: {
-        // pointerEvents: "none",
-      },
-    },
   },
 });

--- a/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.css.ts
@@ -118,10 +118,10 @@ export const stackWrapper = recipe({
     globalTransitionState: {
       idle: {},
       loading: {
-        pointerEvents: "none",
+        // pointerEvents: "none",
       },
       paused: {
-        pointerEvents: "none",
+        // pointerEvents: "none",
       },
     },
   },

--- a/extensions/plugin-basic-ui/src/basicUIPlugin.tsx
+++ b/extensions/plugin-basic-ui/src/basicUIPlugin.tsx
@@ -61,7 +61,6 @@ export const basicUIPlugin: (
           className={compact([
             css.stackWrapper({
               theme: initialContext?.theme ?? _options.theme,
-              globalTransitionState: stack.globalTransitionState,
             }),
             _options.rootClassName,
           ]).join(" ")}

--- a/extensions/plugin-basic-ui/src/components/AppScreen.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.tsx
@@ -4,14 +4,14 @@ import {
   useLazy,
   useMounted,
   useNullableActivity,
-  usePreventTouchEvents,
+  usePreventTouchDuringTransition,
   useStyleEffectHide,
   useStyleEffectOffset,
   useStyleEffectSwipeBack,
   useZIndexBase,
 } from "@stackflow/react-ui-core";
 import { assignInlineVars } from "@vanilla-extract/dynamic";
-import { createContext, useContext, useEffect, useMemo, useRef } from "react";
+import { createContext, useContext, useMemo, useRef } from "react";
 import { useGlobalOptions } from "../basicUIPlugin";
 import type { GlobalVars } from "../basicUIPlugin.css";
 import { globalVars } from "../basicUIPlugin.css";
@@ -195,7 +195,7 @@ const AppScreen: React.FC<AppScreenProps> = ({
     }
   };
 
-  usePreventTouchEvents({
+  usePreventTouchDuringTransition({
     appScreenRef,
   });
 

--- a/extensions/plugin-basic-ui/src/components/AppScreen.tsx
+++ b/extensions/plugin-basic-ui/src/components/AppScreen.tsx
@@ -1,16 +1,17 @@
-import { useActions } from "@stackflow/react";
+import { useActions, useStack } from "@stackflow/react";
 import {
   useActivityDataAttributes,
   useLazy,
   useMounted,
   useNullableActivity,
+  usePreventTouchEvents,
   useStyleEffectHide,
   useStyleEffectOffset,
   useStyleEffectSwipeBack,
   useZIndexBase,
 } from "@stackflow/react-ui-core";
 import { assignInlineVars } from "@vanilla-extract/dynamic";
-import { createContext, useContext, useMemo, useRef } from "react";
+import { createContext, useContext, useEffect, useMemo, useRef } from "react";
 import { useGlobalOptions } from "../basicUIPlugin";
 import type { GlobalVars } from "../basicUIPlugin.css";
 import { globalVars } from "../basicUIPlugin.css";
@@ -193,6 +194,10 @@ const AppScreen: React.FC<AppScreenProps> = ({
       });
     }
   };
+
+  usePreventTouchEvents({
+    appScreenRef,
+  });
 
   return (
     <Context.Provider

--- a/extensions/react-ui-core/src/index.ts
+++ b/extensions/react-ui-core/src/index.ts
@@ -8,3 +8,4 @@ export * from "./useStyleEffectOffset";
 export * from "./useStyleEffectSwipeBack";
 export * from "./useZIndexBase";
 export * from "./useActivityDataAttributes";
+export * from "./usePreventTouchEvents";

--- a/extensions/react-ui-core/src/index.ts
+++ b/extensions/react-ui-core/src/index.ts
@@ -8,4 +8,4 @@ export * from "./useStyleEffectOffset";
 export * from "./useStyleEffectSwipeBack";
 export * from "./useZIndexBase";
 export * from "./useActivityDataAttributes";
-export * from "./usePreventTouchEvents";
+export * from "./usePreventTouchDuringTransition";

--- a/extensions/react-ui-core/src/usePreventTouchDuringTransition.ts
+++ b/extensions/react-ui-core/src/usePreventTouchDuringTransition.ts
@@ -1,7 +1,7 @@
 import { useStack } from "@stackflow/react";
 import { useEffect } from "react";
 
-export function usePreventTouchEvents({
+export function usePreventTouchDuringTransition({
   appScreenRef,
 }: {
   appScreenRef: React.RefObject<HTMLDivElement>;

--- a/extensions/react-ui-core/src/usePreventTouchEvents.ts
+++ b/extensions/react-ui-core/src/usePreventTouchEvents.ts
@@ -1,0 +1,37 @@
+import { useStack } from "@stackflow/react";
+import { useEffect } from "react";
+
+export function usePreventTouchEvents({
+  appScreenRef,
+}: {
+  appScreenRef: React.RefObject<HTMLDivElement>;
+}) {
+  const { globalTransitionState } = useStack();
+
+  useEffect(() => {
+    const $appScreen = appScreenRef.current;
+    if (!$appScreen) {
+      return;
+    }
+
+    if (globalTransitionState === "idle") {
+      return;
+    }
+
+    const onTouchStart = (e: TouchEvent) => {
+      e.preventDefault();
+    };
+
+    const onTouchEnd = (e: TouchEvent) => {
+      e.preventDefault();
+    };
+
+    $appScreen.addEventListener("touchstart", onTouchStart);
+    $appScreen.addEventListener("touchend", onTouchEnd);
+
+    return () => {
+      $appScreen.removeEventListener("touchstart", onTouchStart);
+      $appScreen.removeEventListener("touchend", onTouchEnd);
+    };
+  }, [globalTransitionState]);
+}

--- a/extensions/react-ui-core/src/usePreventTouchEvents.ts
+++ b/extensions/react-ui-core/src/usePreventTouchEvents.ts
@@ -10,11 +10,7 @@ export function usePreventTouchEvents({
 
   useEffect(() => {
     const $appScreen = appScreenRef.current;
-    if (!$appScreen) {
-      return;
-    }
-
-    if (globalTransitionState === "idle") {
+    if (!$appScreen || globalTransitionState === "idle") {
       return;
     }
 
@@ -22,16 +18,10 @@ export function usePreventTouchEvents({
       e.preventDefault();
     };
 
-    const onTouchEnd = (e: TouchEvent) => {
-      e.preventDefault();
-    };
-
     $appScreen.addEventListener("touchstart", onTouchStart);
-    $appScreen.addEventListener("touchend", onTouchEnd);
 
     return () => {
       $appScreen.removeEventListener("touchstart", onTouchStart);
-      $appScreen.removeEventListener("touchend", onTouchEnd);
     };
   }, [globalTransitionState]);
 }


### PR DESCRIPTION
In iOS Safari, there is a behavior that the scroll target is focused to the initially touched element until the scroll momentum ends, even if the target element is unmounted or the momentum itself is initially zero.

This behavior can be a problematic when `pointer-events: none;` property is set to stack wrapper element because the scrolling is attempted on an unintended target (usually a document element) and the continuous reviving of the momentum by touches can be keeping the `AppScreen` unscrollable forever.

Therefore, a handler has been added to the `AppScreen` component to prevent `touchstart` events instead using the `pointer-events: none;` style property for the original purpose of preventing the user-side action during transitions.