### PR TITLE
feat: Add context validation to useActivityParams hook

### DIFF
--- a/integrations/react/src/future/useActivityParams.ts
+++ b/integrations/react/src/future/useActivityParams.ts
@@ -8,6 +8,11 @@ import { ActivityContext } from "../__internal__/activity/ActivityProvider";
 export function useActivityParams<
   ActivityName extends RegisteredActivityName,
 >(): InferActivityParams<ActivityName> {
-  return useContext(ActivityContext)
-    .params as InferActivityParams<ActivityName>;
+  const context = useContext(ActivityContext);
+
+  if (!context) {
+    throw new Error("useActivityParams must be used within Stack");
+  }
+
+  return context.params as InferActivityParams<ActivityName>;
 }


### PR DESCRIPTION
### AS-IS
If `useActivityParams` is used outside of Stack, there's an error:
`Uncaught TypeError: Cannot read properties of null (reading 'params')`

### TO-BE
Throw error with clear message(`useActivityParams must be used within Stack`) when `useActivityParams` is used outside of Stack context to provide debugging information for improper usage.
