### PR TITLE
fix(plugin-history-sync): only call fallbackActivity when no route matches

### DIFF
--- a/.changeset/fix-fallback-activity-called-on-match.md
+++ b/.changeset/fix-fallback-activity-called-on-match.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-history-sync": patch
+---
+
+Fix `fallbackActivity` callback being invoked on every initialization regardless of route matching outcome. Restored the pre-1.8.0 contract: the callback is now called only when no route matches `currentPath`. Apps that perform side effects in this callback (e.g. Sentry logging for unknown deep links) no longer fire on successful matches.

--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -175,7 +175,7 @@ describe("historySyncPlugin", () => {
       initialEntries: ["/articles/123"],
     });
 
-    const fallbackActivity = jest.fn(() => "Home");
+    const fallbackActivity = jest.fn((): "Home" => "Home");
 
     stackflow({
       activityNames: ["Home", "Article"],
@@ -199,7 +199,7 @@ describe("historySyncPlugin", () => {
       initialEntries: ["/non-existent-path"],
     });
 
-    const fallbackActivity = jest.fn(() => "Home");
+    const fallbackActivity = jest.fn((): "Home" => "Home");
 
     stackflow({
       activityNames: ["Home", "Article"],

--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -194,28 +194,29 @@ describe("historySyncPlugin", () => {
     expect(fallbackActivity).not.toHaveBeenCalled();
   });
 
-  test("historySyncPlugin - 초기에 매칭하는 라우트가 없으면 fallbackActivity 콜백을 호출합니다", async () => {
+  test("historySyncPlugin - 초기에 매칭하는 라우트가 없으면 fallbackActivity 콜백을 plugin instance당 한 번만 호출합니다", async () => {
     history = createMemoryHistory({
       initialEntries: ["/non-existent-path"],
     });
 
     const fallbackActivity = jest.fn((): "Home" => "Home");
 
-    stackflow({
-      activityNames: ["Home", "Article"],
-      plugins: [
-        historySyncPlugin({
-          history,
-          routes: {
-            Home: "/home",
-            Article: "/articles/:articleId",
-          },
-          fallbackActivity,
-        }),
-      ],
+    const plugin = historySyncPlugin({
+      history,
+      routes: {
+        Home: "/home",
+        Article: "/articles/:articleId",
+      },
+      fallbackActivity,
     });
 
-    expect(fallbackActivity).toHaveBeenCalled();
+    const pluginInstance = plugin();
+    pluginInstance.overrideInitialEvents?.({
+      initialEvents: [],
+      initialContext: {},
+    });
+
+    expect(fallbackActivity).toHaveBeenCalledTimes(1);
   });
 
   test("historySyncPlugin - actions.push() 후에, URL 상태가 알맞게 바뀝니다", async () => {

--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -170,6 +170,54 @@ describe("historySyncPlugin", () => {
     expect(activeActivity(actions.getStack())?.params.title).toEqual("hello");
   });
 
+  test("historySyncPlugin - 초기에 매칭하는 라우트가 있으면 fallbackActivity 콜백을 호출하지 않습니다", async () => {
+    history = createMemoryHistory({
+      initialEntries: ["/articles/123"],
+    });
+
+    const fallbackActivity = jest.fn(() => "Home");
+
+    stackflow({
+      activityNames: ["Home", "Article"],
+      plugins: [
+        historySyncPlugin({
+          history,
+          routes: {
+            Home: "/home",
+            Article: "/articles/:articleId",
+          },
+          fallbackActivity,
+        }),
+      ],
+    });
+
+    expect(fallbackActivity).not.toHaveBeenCalled();
+  });
+
+  test("historySyncPlugin - 초기에 매칭하는 라우트가 없으면 fallbackActivity 콜백을 호출합니다", async () => {
+    history = createMemoryHistory({
+      initialEntries: ["/non-existent-path"],
+    });
+
+    const fallbackActivity = jest.fn(() => "Home");
+
+    stackflow({
+      activityNames: ["Home", "Article"],
+      plugins: [
+        historySyncPlugin({
+          history,
+          routes: {
+            Home: "/home",
+            Article: "/articles/:articleId",
+          },
+          fallbackActivity,
+        }),
+      ],
+    });
+
+    expect(fallbackActivity).toHaveBeenCalled();
+  });
+
   test("historySyncPlugin - actions.push() 후에, URL 상태가 알맞게 바뀝니다", async () => {
     await actions.push({
       activityId: "a1",

--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -228,22 +228,21 @@ export function historySyncPlugin<
         }
 
         const currentPath = resolveCurrentPath();
-        const fallbackActivityName = options.fallbackActivity({
-          initialContext,
+        const matchedActivityRoute = activityRoutes.find((activityRoute) => {
+          const template = makeTemplate(
+            activityRoute,
+            options.urlPatternOptions,
+          );
+          const activityParams = template.parse(currentPath);
+
+          return activityParams !== null;
         });
         const targetActivityRoute =
-          activityRoutes.find((activityRoute) => {
-            const template = makeTemplate(
-              activityRoute,
-              options.urlPatternOptions,
-            );
-            const activityParams = template.parse(currentPath);
-
-            return activityParams !== null;
-          }) ??
+          matchedActivityRoute ??
           activityRoutes.find(
             (activityRoute) =>
-              activityRoute.activityName === fallbackActivityName,
+              activityRoute.activityName ===
+              options.fallbackActivity({ initialContext }),
           )!;
         const pattern = new UrlPattern(
           `${targetActivityRoute.path}(/)`,

--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -237,13 +237,18 @@ export function historySyncPlugin<
 
           return activityParams !== null;
         });
-        const targetActivityRoute =
-          matchedActivityRoute ??
-          activityRoutes.find(
+        const targetActivityRoute = (() => {
+          if (matchedActivityRoute) {
+            return matchedActivityRoute;
+          }
+          const fallbackActivityName = options.fallbackActivity({
+            initialContext,
+          });
+          return activityRoutes.find(
             (activityRoute) =>
-              activityRoute.activityName ===
-              options.fallbackActivity({ initialContext }),
+              activityRoute.activityName === fallbackActivityName,
           )!;
+        })();
         const pattern = new UrlPattern(
           `${targetActivityRoute.path}(/)`,
           options.urlPatternOptions,


### PR DESCRIPTION
## Summary

- `fallbackActivity` callback was being invoked on every initialization regardless of whether `currentPath` matched a registered route, due to a refactor in #610 that hoisted the call out of the no-match branch in order to unify the matched/fallback `targetActivityRoute` for `defaultHistory`.
- This regressed the pre-1.8.0 contract: apps performing side effects in this callback (e.g. logging unknown deep links) fired on every successful match too. The fix lazy-evaluates the fallback inside `??`, restoring the original behavior while keeping `defaultHistory` support intact.
- Added two regression tests asserting the callback is not called on a successful match and is called when no route matches.

## Test plan

- [x] `yarn test historySyncPlugin.spec` — 29/29 passing
- [x] Verified the new test catches the regression by temporarily reverting the fix