### PR TITLE
docs: convert 6 plugin API reference docs to v2 config-first pattern (FEP-2340)

### DIFF
--- a/docs/pages/api-references/plugins/plugin-basic-ui.en.mdx
+++ b/docs/pages/api-references/plugins/plugin-basic-ui.en.mdx
@@ -13,12 +13,36 @@ npm install @stackflow/plugin-basic-ui
 ## Usage
 
 Provides components in the form of application app bars.
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```tsx showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { basicUIPlugin } from "@stackflow/plugin-basic-ui";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
+  },
   plugins: [
     // ...
     basicUIPlugin({

--- a/docs/pages/api-references/plugins/plugin-basic-ui.ko.mdx
+++ b/docs/pages/api-references/plugins/plugin-basic-ui.ko.mdx
@@ -13,12 +13,36 @@ npm install @stackflow/plugin-basic-ui
 ## 사용법
 
 어플리케이션 앱바 형태의 컴포넌트를 제공해요.
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```tsx showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { basicUIPlugin } from "@stackflow/plugin-basic-ui";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
+  },
   plugins: [
     // ...
     basicUIPlugin({

--- a/docs/pages/api-references/plugins/plugin-devtools.en.mdx
+++ b/docs/pages/api-references/plugins/plugin-devtools.en.mdx
@@ -11,13 +11,35 @@ npm install @stackflow/plugin-devtools
 ## Usage
 
 To utilize the plugin, integrate it within your Stackflow setup as shown:
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```tsx showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { devtoolsPlugin } from "@stackflow/plugin-devtools";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  activities: {
-    // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
   },
   plugins: [
     devtoolsPlugin(),
@@ -25,4 +47,3 @@ const { Stack, useFlow } = stackflow({
   ],
 });
 ```
-

--- a/docs/pages/api-references/plugins/plugin-devtools.ko.mdx
+++ b/docs/pages/api-references/plugins/plugin-devtools.ko.mdx
@@ -10,13 +10,35 @@ npm install @stackflow/plugin-devtools
 
 ## 사용법
 
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```tsx showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { devtoolsPlugin } from "@stackflow/plugin-devtools";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  activities: {
-    // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
   },
   plugins: [
     devtoolsPlugin(),

--- a/docs/pages/api-references/plugins/plugin-google-analytics-4.en.mdx
+++ b/docs/pages/api-references/plugins/plugin-google-analytics-4.en.mdx
@@ -13,13 +13,35 @@ npm install @stackflow/plugin-google-analytics-4
 ## Usage
 ### Initialize
 
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```tsx showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { googleAnalyticsPlugin } from "@stackflow/plugin-google-analytics-4";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  activities: {
-    // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
   },
   plugins: [
     googleAnalyticsPlugin({
@@ -42,6 +64,7 @@ const { Stack, useFlow } = stackflow({
 ### Set config
 
 ```tsx showLineNumbers filename="App.tsx" copy
+import { useEffect } from "react";
 import { useGoogleAnalyticsContext } from "@stackflow/plugin-google-analytics-4";
 
 const App = () => {
@@ -57,7 +80,7 @@ const App = () => {
       //  GA4 config values.
       // https://bit.ly/3Y7IXhV
     });
-  }, []);
+  }, [setConfig]);
 
   return <div>...</div>;
 };

--- a/docs/pages/api-references/plugins/plugin-google-analytics-4.ko.mdx
+++ b/docs/pages/api-references/plugins/plugin-google-analytics-4.ko.mdx
@@ -13,13 +13,35 @@ npm install @stackflow/plugin-google-analytics-4
 ## 사용법
 ### 초기화
 
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```tsx showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { googleAnalyticsPlugin } from "@stackflow/plugin-google-analytics-4";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  activities: {
-    // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
   },
   plugins: [
     googleAnalyticsPlugin({
@@ -42,6 +64,7 @@ const { Stack, useFlow } = stackflow({
 ### config 세팅
 
 ```tsx showLineNumbers filename="App.tsx" copy
+import { useEffect } from "react";
 import { useGoogleAnalyticsContext } from "@stackflow/plugin-google-analytics-4";
 
 const App = () => {
@@ -57,7 +80,7 @@ const App = () => {
       //  GA4 config values.
       // https://bit.ly/3Y7IXhV
     });
-  }, []);
+  }, [setConfig]);
 
   return <div>...</div>;
 };

--- a/docs/pages/api-references/plugins/plugin-renderer-basic.en.mdx
+++ b/docs/pages/api-references/plugins/plugin-renderer-basic.en.mdx
@@ -10,13 +10,35 @@ npm install @stackflow/plugin-renderer-basic
 
 ## Usage
 
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```ts showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { basicRendererPlugin } from "@stackflow/plugin-renderer-basic";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  activities: {
-    // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
   },
   plugins: [basicRendererPlugin()],
 });

--- a/docs/pages/api-references/plugins/plugin-renderer-basic.ko.mdx
+++ b/docs/pages/api-references/plugins/plugin-renderer-basic.ko.mdx
@@ -10,13 +10,35 @@ npm install @stackflow/plugin-renderer-basic
 
 ## 사용법
 
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```ts showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { basicRendererPlugin } from "@stackflow/plugin-renderer-basic";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  activities: {
-    // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
   },
   plugins: [basicRendererPlugin()],
 });

--- a/docs/pages/api-references/plugins/plugin-renderer-web.en.mdx
+++ b/docs/pages/api-references/plugins/plugin-renderer-web.en.mdx
@@ -10,13 +10,35 @@ npm install @stackflow/plugin-renderer-web
 
 ## Usage
 
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```ts showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { webRendererPlugin } from "@stackflow/plugin-renderer-web";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  activities: {
-    // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
   },
   plugins: [webRendererPlugin()],
 });

--- a/docs/pages/api-references/plugins/plugin-renderer-web.ko.mdx
+++ b/docs/pages/api-references/plugins/plugin-renderer-web.ko.mdx
@@ -10,15 +10,36 @@ npm install @stackflow/plugin-renderer-web
 
 ## 사용법
 
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```ts showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { webRendererPlugin } from "@stackflow/plugin-renderer-web";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  activities: {
-    // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
   },
   plugins: [webRendererPlugin()],
 });
 ```
-

--- a/docs/pages/api-references/plugins/plugin-stack-depth-change.en.mdx
+++ b/docs/pages/api-references/plugins/plugin-stack-depth-change.en.mdx
@@ -12,13 +12,35 @@ npm install @stackflow/plugin-stack-depth-change
 
 ## Usage
 
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```ts showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { stackDepthChangePlugin } from "@stackflow/plugin-stack-depth-change";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  activities: {
-    // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
   },
   plugins: [
     // ...

--- a/docs/pages/api-references/plugins/plugin-stack-depth-change.ko.mdx
+++ b/docs/pages/api-references/plugins/plugin-stack-depth-change.ko.mdx
@@ -12,13 +12,35 @@ npm install @stackflow/plugin-stack-depth-change
 
 ## 사용법
 
+```ts showLineNumbers filename="stackflow.config.ts" copy
+import { defineConfig } from "@stackflow/config";
+
+export const config = defineConfig({
+  activities: [
+    {
+      name: "MyHome",
+      route: "/",
+    },
+    {
+      name: "MyArticle",
+      route: "/articles/:articleId",
+    },
+  ],
+});
+```
+
 ```ts showLineNumbers filename="stackflow.ts" copy
 import { stackflow } from "@stackflow/react";
 import { stackDepthChangePlugin } from "@stackflow/plugin-stack-depth-change";
+import { config } from "./stackflow.config";
+import { MyHome } from "./MyHome";
+import { MyArticle } from "./MyArticle";
 
-const { Stack, useFlow } = stackflow({
-  activities: {
-    // ...
+const { Stack } = stackflow({
+  config,
+  components: {
+    MyHome,
+    MyArticle,
   },
   plugins: [
     // ...


### PR DESCRIPTION
## Summary

PR #695의 follow-up. `plugin-history-sync`를 제외한 6개 plugin API reference 문서가 여전히 v1 패턴(`const { Stack, useFlow } = stackflow({ activities: { ... } })`)을 노출하고 있어 v2 config-first 패턴으로 통일.

Linear: [FEP-2340](https://linear.app/daangn/issue/FEP-2340)
Parent umbrella: [FEP-2117](https://linear.app/daangn/issue/FEP-2117)

## Changes

각 plugin EN/KO 페어를 한 커밋으로 묶어 의미 단위 분리:

- \`f8b41212\` docs(plugin-basic-ui): convert API reference examples to v2 config-first pattern
- \`7654801c\` docs(plugin-devtools): convert API reference examples to v2 config-first pattern
- \`50b92090\` docs(plugin-google-analytics-4): convert API reference examples to v2 config-first pattern
- \`ae592b04\` docs(plugin-renderer-basic): convert API reference examples to v2 config-first pattern
- \`f72c0d38\` docs(plugin-renderer-web): convert API reference examples to v2 config-first pattern
- \`c0ae80ec\` docs(plugin-stack-depth-change): convert API reference examples to v2 config-first pattern

부수 처리:
- \`plugin-google-analytics-4\` EN/KO 예제에 \`import { useEffect } from \"react\";\` 누락 보완 + dependency 배열 \`[setConfig]\` 정돈 (FEP-2129 iter3 reviewer가 함께 식별)
- 다른 plugin 문서에는 같은 패턴 없음을 grep으로 확인

## Test plan

- [x] \`yarn workspace @stackflow/docs build\` 통과
- [x] \`yarn typecheck\` 통과
- [x] 변경 범위가 지정 12개 문서로 한정
- [ ] worker↔reviewer 외부 검수 진행 예정

## Notes

- Base는 \`tony/future-to-stable-plan\` (stacked PR). PR #695 머지 시 GitHub이 base를 main으로 자동 갱신
- PR #695와는 다른 파일을 만지므로 충돌 없음