### PR TITLE
ci(release): pin Node version in release.yml to avoid v24.15.0 EBADF regression (FEP-2344)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24.x
+          node-version: 24.14.1
           registry-url: https://registry.npmjs.org
 
       - uses: actions/cache@v4


### PR DESCRIPTION
## Summary

Pin the release workflow Node version to `24.14.1` so GitHub Actions does not resolve `24.x` to Node `24.15.0`, which currently hits an EBADF regression during Yarn Berry PnP ESM/CJS loader startup.

This is isolated from the PR #695 work line: the failure was found while checking that branch, but the affected workflow runs on PR pushes and main pushes independently of that feature work.

## Version choice

Chose `24.14.1` over `"22"`. `build.yml` and `integration.yml` already use Node 22, but `release.yml` was the only workflow intentionally tracking Node 24. Pinning to `24.14.1` keeps that release-workflow intent while avoiding the known `24.15.0` regression, and it gives us a small revert once Node ships a fix.

## Links

- Linear: https://linear.app/daangn/issue/FEP-2344/releaseyml의-node-24150-ebadf-회귀-회피-node-버전-핀
- nodejs/node#62786: https://github.com/nodejs/node/issues/62786
- nodejs/node#62012: https://github.com/nodejs/node/issues/62012
- yarnpkg/berry#7065: https://github.com/yarnpkg/berry/issues/7065
- nodejs/corepack#813: https://github.com/nodejs/corepack/issues/813

## Test plan

- `git diff --check`
- Confirmed changed files are limited to `.github/workflows/release.yml`
- `actionlint` is not installed locally, so YAML was checked by direct inspection of the one-line scalar value change
- Existing build/integration workflows are unaffected. After this PR merges, monitor the first release workflow run on main.