### PR TITLE
fix(plugin-sentry): add publishConfig access public so release can publish (FEP-2358)

### DIFF
--- a/.changeset/plugin-sentry-publish-access.md
+++ b/.changeset/plugin-sentry-publish-access.md
@@ -1,7 +1,4 @@
 ---
-"@stackflow/plugin-sentry": patch
 ---
 
-Add `publishConfig: { access: "public" }` so the release workflow can publish the package.
-
-`@stackflow/plugin-sentry` was the only package missing this field. Without it, scoped packages default to `restricted` access and `changeset publish` fails with `E402 Payment Required` (the @stackflow org has no private plan). This was masked while `0.1.0` matched the repo version (publish was skipped as "already published") and surfaced once `0.1.1` triggered an actual publish.
+`publishConfig: { access: "public" }` 추가는 공개 API/런타임 변경이 없는 릴리스 메타데이터 수정이므로 버전 bump 없이 처리합니다. (PR `changeset status` 게이트 통과용 empty changeset)

--- a/.changeset/plugin-sentry-publish-access.md
+++ b/.changeset/plugin-sentry-publish-access.md
@@ -1,0 +1,7 @@
+---
+"@stackflow/plugin-sentry": patch
+---
+
+Add `publishConfig: { access: "public" }` so the release workflow can publish the package.
+
+`@stackflow/plugin-sentry` was the only package missing this field. Without it, scoped packages default to `restricted` access and `changeset publish` fails with `E402 Payment Required` (the @stackflow org has no private plan). This was masked while `0.1.0` matched the repo version (publish was skipped as "already published") and surfaced once `0.1.1` triggered an actual publish.

--- a/extensions/plugin-sentry/package.json
+++ b/extensions/plugin-sentry/package.json
@@ -41,5 +41,8 @@
     "@stackflow/esbuild-config": "^1.0.3",
     "esbuild": "^0.23.0",
     "typescript": "^5.5.3"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## 배경

stackflow는 npm **OIDC trusted publishing**으로 배포한다(`release.yml`). `@stackflow/plugin-sentry`는 신규 패키지라 첫 배포(`0.1.0`)를 로컬에서 수동 부트스트랩한 뒤 이후 버전부터 CI가 인계받는 흐름인데, **이 패키지에만 `publishConfig: { access: "public" }`가 없다**(이력상 한 번도 없음).

그래서 scoped 패키지 기본값인 `restricted`로 게시가 나가고, @stackflow org에 private 플랜이 없어 `changeset publish`가 **E402 Payment Required**로 실패한다. `0.1.0`이 레포 버전과 같던 동안은 CI가 "이미 게시됨"으로 skip해 가려져 있었고, #709에서 `0.1.1`로 bump되며 CI가 실제 게시를 시도하는 순간 드러났다. 부수 효과로 publish 스텝이 sentry에서 비정상 종료 → changesets action의 후속 단계(git 태그 + GitHub Release 생성)가 미실행됐다.

## 변경

- `extensions/plugin-sentry/package.json`에 다른 모든 패키지와 동일하게 `"publishConfig": { "access": "public" }` 추가
- **empty changeset** 추가 — publishConfig는 공개 API/런타임 변경이 없는 릴리스 메타데이터 수정이라 버전 bump 없이 처리. PR의 `changeset status` 게이트만 통과시킨다.

## 머지 후 동작 (의도)

`changesets/action@v1`은 "changeset이 존재하지만 전부 empty"인 경우 publish 경로보다 **먼저** `All changesets are empty; not creating PR`로 early-return한다. 따라서:

1. 이 PR 머지 → main에 publishConfig 반영 + empty changeset 존재 → 다음 Release run은 **publish를 시도하지 않고 early-return** → 지금까지 매 run 터지던 **E402 red가 멈춘다**.
2. 단, empty changeset만 단독으로 남아있는 동안은 Release 자동화가 정지 상태이고 `plugin-sentry@0.1.1`은 **자동 게시되지 않는다**.
3. 실제 `0.1.1` 게시는 empty changeset이 비워질 때 일어난다 — 후속에서 제거하거나, 다음 비어있지 않은 changeset의 Version PR가 함께 소비한 뒤 main에 changeset이 없어지면 publish 경로가 돌아 `0.1.1`(현재 버전 그대로)을 `public`으로 게시한다.

## 확인 사항

- [x] `publishConfig: {access: "public"}` 추가 (+ empty changeset)
- [ ] 머지 후 Release run에서 E402 red 해소(green) 확인
- [ ] `plugin-sentry@0.1.1` 게시 트리거(empty changeset 정리 시점) 확인

Resolves FEP-2358

🤖 Generated with [Claude Code](https://claude.com/claude-code)