### PR TITLE
feat(plugin-history-sync): expose initialContext to defaultHistory

### DIFF
--- a/.changeset/tidy-bats-context.md
+++ b/.changeset/tidy-bats-context.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-history-sync": minor
+---
+
+Pass `initialContext` to route `defaultHistory` callbacks so the initial stack can depend on request-specific context.

--- a/extensions/plugin-history-sync/src/RouteLike.ts
+++ b/extensions/plugin-history-sync/src/RouteLike.ts
@@ -16,6 +16,7 @@ export type Route<ComponentType> = {
   ) => Record<string, string | undefined>;
   defaultHistory?: (
     params: Record<string, string>,
+    args: { initialContext: any },
   ) => HistoryEntry[] | DefaultHistoryDescriptor;
 };
 
@@ -45,13 +46,15 @@ export function interpretDefaultHistoryOption(
   option:
     | ((
         params: Record<string, string>,
+        args: { initialContext: any },
       ) => HistoryEntry[] | DefaultHistoryDescriptor)
     | undefined,
   params: Record<string, string>,
+  initialContext: any,
 ): DefaultHistoryDescriptor {
   if (!option) return { entries: [] };
 
-  const entriesOrDescriptor = option(params);
+  const entriesOrDescriptor = option(params, { initialContext });
 
   if (Array.isArray(entriesOrDescriptor)) {
     return { entries: entriesOrDescriptor };

--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -219,6 +219,52 @@ describe("historySyncPlugin", () => {
     expect(fallbackActivity).toHaveBeenCalledTimes(1);
   });
 
+  test("defaultHistory receives initialContext", () => {
+    history = createMemoryHistory({
+      initialEntries: ["/articles/123"],
+    });
+
+    const initialContext = {
+      defaultHistoryActivityName: "Home" as const,
+    };
+    const defaultHistory = jest.fn(
+      (
+        _params: Record<string, string>,
+        args: { initialContext: typeof initialContext },
+      ) => [
+        {
+          activityName: args.initialContext.defaultHistoryActivityName,
+          activityParams: {},
+        },
+      ],
+    );
+    const plugin = historySyncPlugin({
+      history,
+      routes: {
+        Home: "/home",
+        Article: {
+          path: "/articles/:articleId",
+          defaultHistory,
+        },
+      },
+      fallbackActivity: () => "Home",
+    });
+
+    const initialEvents = plugin().overrideInitialEvents?.({
+      initialEvents: [],
+      initialContext,
+    });
+
+    expect(defaultHistory).toHaveBeenCalledWith(
+      { articleId: "123" },
+      { initialContext },
+    );
+    expect(initialEvents?.[0]).toMatchObject({
+      name: "Pushed",
+      activityName: "Home",
+    });
+  });
+
   test("historySyncPlugin - actions.push() 후에, URL 상태가 알맞게 바뀝니다", async () => {
     await actions.push({
       activityId: "a1",

--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -219,52 +219,6 @@ describe("historySyncPlugin", () => {
     expect(fallbackActivity).toHaveBeenCalledTimes(1);
   });
 
-  test("defaultHistory receives initialContext", () => {
-    history = createMemoryHistory({
-      initialEntries: ["/articles/123"],
-    });
-
-    const initialContext = {
-      defaultHistoryActivityName: "Home" as const,
-    };
-    const defaultHistory = jest.fn(
-      (
-        _params: Record<string, string>,
-        args: { initialContext: typeof initialContext },
-      ) => [
-        {
-          activityName: args.initialContext.defaultHistoryActivityName,
-          activityParams: {},
-        },
-      ],
-    );
-    const plugin = historySyncPlugin({
-      history,
-      routes: {
-        Home: "/home",
-        Article: {
-          path: "/articles/:articleId",
-          defaultHistory,
-        },
-      },
-      fallbackActivity: () => "Home",
-    });
-
-    const initialEvents = plugin().overrideInitialEvents?.({
-      initialEvents: [],
-      initialContext,
-    });
-
-    expect(defaultHistory).toHaveBeenCalledWith(
-      { articleId: "123" },
-      { initialContext },
-    );
-    expect(initialEvents?.[0]).toMatchObject({
-      name: "Pushed",
-      activityName: "Home",
-    });
-  });
-
   test("historySyncPlugin - actions.push() 후에, URL 상태가 알맞게 바뀝니다", async () => {
     await actions.push({
       activityId: "a1",

--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -10,8 +10,10 @@ import {
   type StackflowActions,
   type StepPushedEvent,
 } from "@stackflow/core";
-import type { StackflowReactPlugin } from "@stackflow/react";
-import type { ActivityComponentType } from "@stackflow/react";
+import type {
+  ActivityComponentType,
+  StackflowReactPlugin,
+} from "@stackflow/react";
 import type { History, Listener } from "history";
 import { createBrowserHistory, createMemoryHistory } from "history";
 import { useEffect, useSyncExternalStore } from "react";
@@ -321,6 +323,7 @@ export function historySyncPlugin<
         const defaultHistory = interpretDefaultHistoryOption(
           targetActivityRoute.defaultHistory,
           params,
+          initialContext,
         );
         const historyEntryToEvents = ({
           activityName,


### PR DESCRIPTION
Pass initialContext to route defaultHistory callbacks as the second argument.