### PR TITLE
fix: support core v2 and v3 peer dependencies (FEP-2590)

### DIFF
--- a/.changeset/fep-2590-core-peer-compat.md
+++ b/.changeset/fep-2590-core-peer-compat.md
@@ -1,0 +1,17 @@
+---
+"@stackflow/react": patch
+"@stackflow/link": patch
+"@stackflow/plugin-basic-ui": patch
+"@stackflow/plugin-blocker": patch
+"@stackflow/plugin-devtools": patch
+"@stackflow/plugin-google-analytics-4": patch
+"@stackflow/plugin-history-sync": patch
+"@stackflow/plugin-lifecycle": patch
+"@stackflow/plugin-renderer-basic": patch
+"@stackflow/plugin-renderer-web": patch
+"@stackflow/plugin-sentry": patch
+"@stackflow/plugin-stack-depth-change": patch
+"@stackflow/react-ui-core": patch
+---
+
+Expand the supported `@stackflow/core` peer dependency range to include both v2 and v3.

--- a/extensions/link/package.json
+++ b/extensions/link/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@stackflow/core": "^3.0.0",
+    "@stackflow/core": "^2.0.0 || ^3.0.0",
     "@stackflow/plugin-history-sync": "^1.6.4-canary.0",
     "@stackflow/react": "^2.0.0",
     "@types/react": ">=16.8.0",

--- a/extensions/plugin-basic-ui/package.json
+++ b/extensions/plugin-basic-ui/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@stackflow/core": "^3.0.0",
+    "@stackflow/core": "^2.0.0 || ^3.0.0",
     "@stackflow/react": "^2.0.0",
     "@types/react": ">=16.8.0",
     "react": ">=16.8.0"

--- a/extensions/plugin-blocker/package.json
+++ b/extensions/plugin-blocker/package.json
@@ -61,7 +61,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@stackflow/core": "^3.0.0",
+    "@stackflow/core": "^2.0.0 || ^3.0.0",
     "@stackflow/react": "^2.0.0",
     "react": ">=16.8.0"
   },

--- a/extensions/plugin-devtools/package.json
+++ b/extensions/plugin-devtools/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@stackflow/core": "^3.0.0"
+    "@stackflow/core": "^2.0.0 || ^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/extensions/plugin-google-analytics-4/package.json
+++ b/extensions/plugin-google-analytics-4/package.json
@@ -45,7 +45,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@stackflow/core": "^3.0.0",
+    "@stackflow/core": "^2.0.0 || ^3.0.0",
     "@stackflow/react": "^2.0.0",
     "@types/react": ">=16.8.0",
     "react": ">=16.8.0"

--- a/extensions/plugin-history-sync/package.json
+++ b/extensions/plugin-history-sync/package.json
@@ -91,7 +91,7 @@
   },
   "peerDependencies": {
     "@stackflow/config": "^1.1.0 || ^2.0.0",
-    "@stackflow/core": "^3.0.0",
+    "@stackflow/core": "^2.0.0 || ^3.0.0",
     "@stackflow/react": "^1.0.0 || ^2.0.0",
     "@types/react": ">=16.8.0",
     "react": ">=16.8.0"

--- a/extensions/plugin-lifecycle/package.json
+++ b/extensions/plugin-lifecycle/package.json
@@ -61,7 +61,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@stackflow/core": "^3.0.0",
+    "@stackflow/core": "^2.0.0 || ^3.0.0",
     "@stackflow/react": "^2.0.0",
     "react": ">=16.8.0"
   },

--- a/extensions/plugin-renderer-basic/package.json
+++ b/extensions/plugin-renderer-basic/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@stackflow/core": "^3.0.0",
+    "@stackflow/core": "^2.0.0 || ^3.0.0",
     "@stackflow/react": "^2.0.0",
     "@types/react": ">=16.8.0",
     "react": ">=16.8.0"

--- a/extensions/plugin-renderer-web/package.json
+++ b/extensions/plugin-renderer-web/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@stackflow/core": "^3.0.0",
+    "@stackflow/core": "^2.0.0 || ^3.0.0",
     "@stackflow/react": "^2.0.0",
     "@types/react": ">=16.8.0",
     "react": ">=16.8.0"

--- a/extensions/plugin-sentry/package.json
+++ b/extensions/plugin-sentry/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@sentry/browser": ">=8.0.0",
     "@sentry/core": ">=8.0.0",
-    "@stackflow/core": "^3.0.0"
+    "@stackflow/core": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@sentry/browser": "^10.46.0",

--- a/extensions/plugin-stack-depth-change/package.json
+++ b/extensions/plugin-stack-depth-change/package.json
@@ -39,7 +39,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@stackflow/core": "^3.0.0"
+    "@stackflow/core": "^2.0.0 || ^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/extensions/react-ui-core/package.json
+++ b/extensions/react-ui-core/package.json
@@ -42,7 +42,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@stackflow/core": "^3.0.0",
+    "@stackflow/core": "^2.0.0 || ^3.0.0",
     "@stackflow/react": "^2.0.0",
     "@types/react": ">=16.8.0",
     "react": ">=16.8.0"

--- a/integrations/react/package.json
+++ b/integrations/react/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "@stackflow/config": "^2.0.0",
-    "@stackflow/core": "^3.0.0",
+    "@stackflow/core": "^2.0.0 || ^3.0.0",
     "@types/react": ">=16.8.0",
     "react": ">=16.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5737,7 +5737,7 @@ __metadata:
     rimraf: "npm:^3.0.2"
     typescript: "npm:^5.5.3"
   peerDependencies:
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
     "@stackflow/plugin-history-sync": ^1.6.4-canary.0
     "@stackflow/react": ^2.0.0
     "@types/react": ">=16.8.0"
@@ -5783,7 +5783,7 @@ __metadata:
     rimraf: "npm:^3.0.2"
     typescript: "npm:^5.5.3"
   peerDependencies:
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
     "@stackflow/react": ^2.0.0
     "@types/react": ">=16.8.0"
     react: ">=16.8.0"
@@ -5813,7 +5813,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     typescript: "npm:^5.5.3"
   peerDependencies:
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
     "@stackflow/react": ^2.0.0
     react: ">=16.8.0"
   languageName: unknown
@@ -5830,7 +5830,7 @@ __metadata:
     rimraf: "npm:^3.0.2"
     typescript: "npm:^5.5.3"
   peerDependencies:
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
   languageName: unknown
   linkType: soft
 
@@ -5848,7 +5848,7 @@ __metadata:
     rimraf: "npm:^3.0.2"
     typescript: "npm:^5.5.3"
   peerDependencies:
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
     "@stackflow/react": ^2.0.0
     "@types/react": ">=16.8.0"
     react: ">=16.8.0"
@@ -5892,7 +5892,7 @@ __metadata:
     url-pattern: "npm:^1.0.3"
   peerDependencies:
     "@stackflow/config": ^1.1.0 || ^2.0.0
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
     "@stackflow/react": ^1.0.0 || ^2.0.0
     "@types/react": ">=16.8.0"
     react: ">=16.8.0"
@@ -5922,7 +5922,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     typescript: "npm:^5.5.3"
   peerDependencies:
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
     "@stackflow/react": ^2.0.0
     react: ">=16.8.0"
   languageName: unknown
@@ -5941,7 +5941,7 @@ __metadata:
     rimraf: "npm:^3.0.2"
     typescript: "npm:^5.5.3"
   peerDependencies:
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
     "@stackflow/react": ^2.0.0
     "@types/react": ">=16.8.0"
     react: ">=16.8.0"
@@ -5961,7 +5961,7 @@ __metadata:
     rimraf: "npm:^3.0.2"
     typescript: "npm:^5.5.3"
   peerDependencies:
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
     "@stackflow/react": ^2.0.0
     "@types/react": ">=16.8.0"
     react: ">=16.8.0"
@@ -5981,7 +5981,7 @@ __metadata:
   peerDependencies:
     "@sentry/browser": ">=8.0.0"
     "@sentry/core": ">=8.0.0"
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
   languageName: unknown
   linkType: soft
 
@@ -5996,7 +5996,7 @@ __metadata:
     rimraf: "npm:^3.0.2"
     typescript: "npm:^5.5.3"
   peerDependencies:
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
   languageName: unknown
   linkType: soft
 
@@ -6013,7 +6013,7 @@ __metadata:
     rimraf: "npm:^3.0.2"
     typescript: "npm:^5.5.3"
   peerDependencies:
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
     "@stackflow/react": ^2.0.0
     "@types/react": ">=16.8.0"
     react: ">=16.8.0"
@@ -6036,7 +6036,7 @@ __metadata:
     typescript: "npm:^5.5.3"
   peerDependencies:
     "@stackflow/config": ^2.0.0
-    "@stackflow/core": ^3.0.0
+    "@stackflow/core": ^2.0.0 || ^3.0.0
     "@types/react": ">=16.8.0"
     react: ">=16.8.0"
   languageName: unknown


### PR DESCRIPTION
## Summary

- expand the `@stackflow/core` peer dependency range from `^3.0.0` to `^2.0.0 || ^3.0.0` across 13 published packages
- keep development dependencies on `@stackflow/core` v3
- add patch changesets for all affected packages and update the lockfile

Linear: https://linear.app/daangn/issue/FEP-2590