### PR TITLE
feat(plugin-stack-persistence): pass Stack to createMetadata

### DIFF
--- a/.changeset/fep-2609-create-metadata-stack.md
+++ b/.changeset/fep-2609-create-metadata-stack.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-stack-persistence": minor
+---
+
+Pass the current `Stack` to `StackSnapshotStrategy.createMetadata`, so metadata can be derived from the same stack state that the snapshot is captured from.

--- a/extensions/plugin-stack-persistence/src/StackSnapshotStrategy.ts
+++ b/extensions/plugin-stack-persistence/src/StackSnapshotStrategy.ts
@@ -1,10 +1,8 @@
-import type { StackSnapshot } from "@stackflow/core";
+import type { Stack, StackSnapshot } from "@stackflow/core";
 import type { StackSnapshotRecord } from "./StackSnapshotRecord";
 
 export interface StackSnapshotStrategy<Metadata> {
-  createMetadata(args: {
-    snapshot: StackSnapshot;
-  }): Metadata;
+  createMetadata(args: { stack: Stack; snapshot: StackSnapshot }): Metadata;
 
   shouldReuse(args: {
     record: StackSnapshotRecord<Metadata>;

--- a/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
+++ b/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
@@ -24,7 +24,7 @@ export function stackPersistencePlugin<Metadata>(
       if (stack.globalTransitionState !== "idle") return;
 
       const snapshot = actions.captureSnapshot();
-      const metadata = strategy.createMetadata({ snapshot });
+      const metadata = strategy.createMetadata({ stack, snapshot });
 
       storage.save({
         snapshot,


### PR DESCRIPTION
## Summary

- pass the current Stack to StackSnapshotStrategy.createMetadata
- keep the Stack and StackSnapshot paired at the same persistence save point

Linear: FEP-2609