### PR TITLE
fix(plugin-stack-persistence): wrap save failures in StackSnapshotRecordSaveError

### DIFF
--- a/.changeset/wrap-record-save-error.md
+++ b/.changeset/wrap-record-save-error.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-stack-persistence": patch
+---
+
+Wrap storage save failures in `StackSnapshotRecordSaveError` before invoking `onRecordSaveError` or rethrowing, matching the declared handler signature and the load-path behavior.

--- a/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
+++ b/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
@@ -30,8 +30,10 @@ export function stackPersistencePlugin<Metadata>(
         snapshot,
         metadata
       }).catch(error => {
-        if (onRecordSaveError) return onRecordSaveError(error);
-        else throw error;
+        const saveError = new StackSnapshotRecordSaveError(error);
+
+        if (onRecordSaveError) return onRecordSaveError(saveError);
+        else throw saveError;
       });
     }
 


### PR DESCRIPTION
## Summary

`onRecordSaveError` is typed as `(error: StackSnapshotRecordSaveError) => void`, but the save path passed the raw storage error straight through, unlike the load path which wraps with `StackSnapshotRecordLoadError`.

- Wrap the caught error in `StackSnapshotRecordSaveError` before invoking `onRecordSaveError`
- Also wrap the rethrown error when no handler is provided, so unhandled rejections are identifiable as snapshot-save failures (original error preserved as `cause`)
- Add a patch changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8n8acsHn8MbiqE2YBwXyc