### PR TITLE
feat(plugin-stack-persistence): add composeStrategies

### DIFF
--- a/.changeset/shaggy-foxes-compose.md
+++ b/.changeset/shaggy-foxes-compose.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-stack-persistence": minor
+---
+
+Add `composeStrategies` to combine keyed snapshot metadata reuse strategies.

--- a/.changeset/shaggy-foxes-compose.md
+++ b/.changeset/shaggy-foxes-compose.md
@@ -2,4 +2,4 @@
 "@stackflow/plugin-stack-persistence": minor
 ---
 
-Add `composeStrategies` to combine keyed snapshot metadata reuse strategies.
+Add `composeStrategies` to combine multiple strategies into one.

--- a/extensions/plugin-stack-persistence/src/composeStrategies.ts
+++ b/extensions/plugin-stack-persistence/src/composeStrategies.ts
@@ -1,6 +1,6 @@
 import type { StackSnapshotStrategy } from "./StackSnapshotStrategy";
 
-type StrategiesMetadata<
+export type StrategiesMetadata<
   Strategies extends Record<string, StackSnapshotStrategy<any>>,
 > = {
   [Key in keyof Strategies]: Strategies[Key] extends StackSnapshotStrategy<
@@ -10,30 +10,40 @@ type StrategiesMetadata<
     : never;
 };
 
-function isMetadataRecord(
+function isComposedStrategyMetadata<Metadata>(
   metadata: unknown,
-): metadata is Record<string, unknown> {
+): metadata is ComposedStrategyMetadata<Metadata> {
   return (
     typeof metadata === "object" &&
-    metadata !== null
+    metadata !== null &&
+    'key' in metadata &&
+    metadata['key'] === 'composed-strategy-metadata-v1'
   );
+}
+
+export interface ComposedStrategyMetadata<Metadata> {
+  key: 'composed-strategy-metadata-v1'
+  composed: Metadata;
 }
 
 export function composeStrategies<
   const Strategies extends Record<string, StackSnapshotStrategy<any>>,
 >(
   strategies: Strategies,
-): StackSnapshotStrategy<StrategiesMetadata<Strategies>> {
+): StackSnapshotStrategy<ComposedStrategyMetadata<StrategiesMetadata<Strategies>>> {
   const keys = Object.keys(strategies) as Array<keyof Strategies>;
 
   return {
     createMetadata(args) {
-      return Object.fromEntries(
-        keys.map((key) => [key, strategies[key].createMetadata(args)]),
-      ) as StrategiesMetadata<Strategies>;
+      return {
+        key: 'composed-strategy-metadata-v1',
+        composed: Object.fromEntries(
+          keys.map((key) => [key, strategies[key].createMetadata(args)]),
+        ) as StrategiesMetadata<Strategies>
+      }
     },
     shouldReuse({ record, initialContext }) {
-      if (!isMetadataRecord(record.metadata)) return false;
+      if (!isComposedStrategyMetadata(record.metadata)) return false;
       if (!keys.every((key) => Object.hasOwn(record.metadata, key))) {
         return false;
       }
@@ -42,7 +52,7 @@ export function composeStrategies<
         return strategies[key].shouldReuse({
           record: {
             ...record,
-            metadata: record.metadata[key],
+            metadata: record.metadata.composed[key],
           },
           initialContext,
         });

--- a/extensions/plugin-stack-persistence/src/composeStrategies.ts
+++ b/extensions/plugin-stack-persistence/src/composeStrategies.ts
@@ -1,0 +1,53 @@
+import type { StackSnapshotStrategy } from "./StackSnapshotStrategy";
+
+type StrategiesMetadata<
+  Strategies extends Record<string, StackSnapshotStrategy<unknown>>,
+> = {
+  [Key in keyof Strategies]: Strategies[Key] extends StackSnapshotStrategy<
+    infer Metadata
+  >
+    ? Metadata
+    : never;
+};
+
+function isMetadataRecord(
+  metadata: unknown,
+): metadata is Record<string, unknown> {
+  return (
+    typeof metadata === "object" &&
+    metadata !== null &&
+    !Array.isArray(metadata)
+  );
+}
+
+export function composeStrategies<
+  Strategies extends Record<string, StackSnapshotStrategy<unknown>>,
+>(
+  strategies: Strategies,
+): StackSnapshotStrategy<StrategiesMetadata<Strategies>> {
+  const keys = Object.keys(strategies) as Array<keyof Strategies>;
+
+  return {
+    createMetadata(args) {
+      return Object.fromEntries(
+        keys.map((key) => [key, strategies[key].createMetadata(args)]),
+      ) as StrategiesMetadata<Strategies>;
+    },
+    shouldReuse({ record, initialContext }) {
+      if (!isMetadataRecord(record.metadata)) return false;
+      if (!keys.every((key) => Object.hasOwn(record.metadata, key))) {
+        return false;
+      }
+
+      return keys.every((key) => {
+        return strategies[key].shouldReuse({
+          record: {
+            ...record,
+            metadata: record.metadata[key],
+          },
+          initialContext,
+        });
+      });
+    },
+  };
+}

--- a/extensions/plugin-stack-persistence/src/composeStrategies.ts
+++ b/extensions/plugin-stack-persistence/src/composeStrategies.ts
@@ -35,11 +35,7 @@ export function composeStrategies<
     },
     shouldReuse({ record, initialContext }) {
       if (!isMetadataRecord(record.metadata)) return false;
-      if (
-        !keys.every((key) =>
-          Object.prototype.hasOwnProperty.call(record.metadata, key),
-        )
-      ) {
+      if (!keys.every((key) => Object.hasOwn(record.metadata, key))) {
         return false;
       }
 

--- a/extensions/plugin-stack-persistence/src/composeStrategies.ts
+++ b/extensions/plugin-stack-persistence/src/composeStrategies.ts
@@ -1,7 +1,7 @@
 import type { StackSnapshotStrategy } from "./StackSnapshotStrategy";
 
 type StrategiesMetadata<
-  Strategies extends Record<string, StackSnapshotStrategy<unknown>>,
+  Strategies extends Record<string, StackSnapshotStrategy<any>>,
 > = {
   [Key in keyof Strategies]: Strategies[Key] extends StackSnapshotStrategy<
     infer Metadata
@@ -15,13 +15,12 @@ function isMetadataRecord(
 ): metadata is Record<string, unknown> {
   return (
     typeof metadata === "object" &&
-    metadata !== null &&
-    !Array.isArray(metadata)
+    metadata !== null
   );
 }
 
 export function composeStrategies<
-  Strategies extends Record<string, StackSnapshotStrategy<unknown>>,
+  const Strategies extends Record<string, StackSnapshotStrategy<any>>,
 >(
   strategies: Strategies,
 ): StackSnapshotStrategy<StrategiesMetadata<Strategies>> {

--- a/extensions/plugin-stack-persistence/src/composeStrategies.ts
+++ b/extensions/plugin-stack-persistence/src/composeStrategies.ts
@@ -10,19 +10,9 @@ export type StrategiesMetadata<
     : never;
 };
 
-function isComposedStrategyMetadata<Metadata>(
-  metadata: unknown,
-): metadata is ComposedStrategyMetadata<Metadata> {
-  return (
-    typeof metadata === "object" &&
-    metadata !== null &&
-    'key' in metadata &&
-    metadata['key'] === 'composed-strategy-metadata-v1'
-  );
-}
-
-export interface ComposedStrategyMetadata<Metadata> {
-  key: 'composed-strategy-metadata-v1'
+export interface ComposeStrategiesMetadata<Metadata> {
+  schema: 'compose-strategy',
+  version: 1,
   composed: Metadata;
 }
 
@@ -30,21 +20,21 @@ export function composeStrategies<
   const Strategies extends Record<string, StackSnapshotStrategy<any>>,
 >(
   strategies: Strategies,
-): StackSnapshotStrategy<ComposedStrategyMetadata<StrategiesMetadata<Strategies>>> {
+): StackSnapshotStrategy<ComposeStrategiesMetadata<StrategiesMetadata<Strategies>>> {
   const keys = Object.keys(strategies) as Array<keyof Strategies>;
 
   return {
     createMetadata(args) {
       return {
-        key: 'composed-strategy-metadata-v1',
+        schema: 'compose-strategy',
+        version: 1,
         composed: Object.fromEntries(
           keys.map((key) => [key, strategies[key].createMetadata(args)]),
         ) as StrategiesMetadata<Strategies>
       }
     },
     shouldReuse({ record, initialContext }) {
-      if (!isComposedStrategyMetadata(record.metadata)) return false;
-      if (!keys.every((key) => Object.hasOwn(record.metadata, key))) {
+      if (!keys.every((key) => Object.hasOwn(record.metadata.composed, key))) {
         return false;
       }
 

--- a/extensions/plugin-stack-persistence/src/composeStrategies.ts
+++ b/extensions/plugin-stack-persistence/src/composeStrategies.ts
@@ -10,31 +10,21 @@ export type StrategiesMetadata<
     : never;
 };
 
-export interface ComposeStrategiesMetadata<Metadata> {
-  schema: 'compose-strategy',
-  version: 1,
-  composed: Metadata;
-}
-
 export function composeStrategies<
   const Strategies extends Record<string, StackSnapshotStrategy<any>>,
 >(
   strategies: Strategies,
-): StackSnapshotStrategy<ComposeStrategiesMetadata<StrategiesMetadata<Strategies>>> {
+): StackSnapshotStrategy<StrategiesMetadata<Strategies>> {
   const keys = Object.keys(strategies) as Array<keyof Strategies>;
 
   return {
     createMetadata(args) {
-      return {
-        schema: 'compose-strategy',
-        version: 1,
-        composed: Object.fromEntries(
-          keys.map((key) => [key, strategies[key].createMetadata(args)]),
-        ) as StrategiesMetadata<Strategies>
-      }
+      return Object.fromEntries(
+        keys.map((key) => [key, strategies[key].createMetadata(args)]),
+      ) as StrategiesMetadata<Strategies>
     },
     shouldReuse({ record, initialContext }) {
-      if (!keys.every((key) => Object.hasOwn(record.metadata.composed, key))) {
+      if (!keys.every((key) => Object.hasOwn(record.metadata, key))) {
         return false;
       }
 
@@ -42,7 +32,7 @@ export function composeStrategies<
         return strategies[key].shouldReuse({
           record: {
             ...record,
-            metadata: record.metadata.composed[key],
+            metadata: record.metadata[key],
           },
           initialContext,
         });

--- a/extensions/plugin-stack-persistence/src/composeStrategies.ts
+++ b/extensions/plugin-stack-persistence/src/composeStrategies.ts
@@ -35,7 +35,11 @@ export function composeStrategies<
     },
     shouldReuse({ record, initialContext }) {
       if (!isMetadataRecord(record.metadata)) return false;
-      if (!keys.every((key) => Object.hasOwn(record.metadata, key))) {
+      if (
+        !keys.every((key) =>
+          Object.prototype.hasOwnProperty.call(record.metadata, key),
+        )
+      ) {
         return false;
       }
 

--- a/extensions/plugin-stack-persistence/src/index.ts
+++ b/extensions/plugin-stack-persistence/src/index.ts
@@ -1,6 +1,7 @@
+export { composeStrategies } from "./composeStrategies";
 export {
+  StackSnapshotRecordLoadError,
   StackSnapshotRecordSaveError,
-  StackSnapshotRecordLoadError
 } from "./errors";
 export { StackSnapshotRecord } from "./StackSnapshotRecord";
 export { StackSnapshotStorage } from "./StackSnapshotStorage";

--- a/extensions/plugin-stack-persistence/src/index.ts
+++ b/extensions/plugin-stack-persistence/src/index.ts
@@ -1,4 +1,8 @@
-export { composeStrategies } from "./composeStrategies";
+export {
+  composeStrategies,
+  type ComposedStrategyMetadata,
+  type StrategiesMetadata
+} from "./composeStrategies";
 export {
   StackSnapshotRecordLoadError,
   StackSnapshotRecordSaveError,

--- a/extensions/plugin-stack-persistence/src/index.ts
+++ b/extensions/plugin-stack-persistence/src/index.ts
@@ -1,6 +1,5 @@
 export {
   composeStrategies,
-  type ComposedStrategyMetadata,
   type StrategiesMetadata
 } from "./composeStrategies";
 export {


### PR DESCRIPTION
## Summary

Adds `composeStrategies`, a utility that composes multiple `StackSnapshotStrategy` instances into one (FEP-2611).

```ts
const strategy = composeStrategies({
  historySync: historySyncStrategy,
  deployVersion: deployVersionStrategy,
});
```

- **Keyed record input** — each key namespaces its strategy's metadata.
- **`createMetadata`** persists each strategy's metadata side by side under its key.
- **`shouldReuse` is AND-composed** — a snapshot is reused only when every strategy agrees; each strategy receives only the metadata under its own key and never learns it was composed.
- **Missing-key fail-safe** — if any configured key is absent from stored metadata (including legacy non-composed / non-object metadata), reuse is rejected without consulting any strategy.
- **Closed under composition** — the result is itself a `StackSnapshotStrategy`, so composed strategies can be nested; `stackPersistencePlugin`'s single-strategy option API is unchanged.
- **Metadata type is inferred** from the input record — no manual type arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMTNfPxft5WXLjpJbN8etC