### PR TITLE
fix(plugin-stack-persistence): report metadata parse failures

### DIFF
--- a/.changeset/fep-2612-parse-metadata.md
+++ b/.changeset/fep-2612-parse-metadata.md
@@ -2,4 +2,4 @@
 "@stackflow/plugin-stack-persistence": major
 ---
 
-`StackSnapshotStrategy` now exposes `metadata.create` and `metadata.parse`, storage loads unknown metadata, and composed strategies persist and validate schema/version envelopes.
+`StackSnapshotStrategy` now exposes `metadata.create` and `metadata.parse`, storage loads unknown metadata, and composed strategies persist and validate schema/version envelopes. Metadata parse failures can include details and are reported through `onRecordLoadError`.

--- a/.changeset/fep-2612-parse-metadata.md
+++ b/.changeset/fep-2612-parse-metadata.md
@@ -2,4 +2,4 @@
 "@stackflow/plugin-stack-persistence": major
 ---
 
-`StackSnapshotStrategy` now exposes `metadata.create` and `metadata.parse`, storage loads unknown metadata, and composed strategies persist and validate schema/version envelopes. Metadata parse failures can include details and are reported through `onMetadataParseError`.
+`StackSnapshotStrategy` now exposes `metadata.create` and `metadata.parse`, storage loads unknown metadata, and composed strategies persist and validate schema/version envelopes. Metadata parse failures can include details and are reported directly through `onRecordLoadError`.

--- a/.changeset/fep-2612-parse-metadata.md
+++ b/.changeset/fep-2612-parse-metadata.md
@@ -2,4 +2,4 @@
 "@stackflow/plugin-stack-persistence": major
 ---
 
-`StackSnapshotStrategy` now exposes `metadata.create` and `metadata.parse`, storage loads unknown metadata, and composed strategies persist and validate schema/version envelopes. Metadata parse failures can include details and are reported through `onRecordLoadError`.
+`StackSnapshotStrategy` now exposes `metadata.create` and `metadata.parse`, storage loads unknown metadata, and composed strategies persist and validate schema/version envelopes. Metadata parse failures can include details and are reported through `onMetadataParseError`.

--- a/extensions/plugin-stack-persistence/src/StackSnapshotMetadataDefinition.ts
+++ b/extensions/plugin-stack-persistence/src/StackSnapshotMetadataDefinition.ts
@@ -7,6 +7,7 @@ export type Result<Value> =
     }
   | {
       ok: false;
+      detail?: unknown;
     };
 
 export interface StackSnapshotMetadataDefinition<Metadata> {

--- a/extensions/plugin-stack-persistence/src/composeStrategies.ts
+++ b/extensions/plugin-stack-persistence/src/composeStrategies.ts
@@ -37,21 +37,43 @@ export function composeStrategies<
       },
       parse(data) {
         if (data === null || typeof data !== "object") {
-          return { ok: false };
+          return {
+            ok: false,
+            detail: "composed strategy metadata must be an object",
+          };
         }
 
         const metadata = data as Record<PropertyKey, unknown>;
 
         if (
           !Object.hasOwn(metadata, "schema") ||
+          metadata.schema !== COMPOSED_METADATA_SCHEMA
+        ) {
+          return {
+            ok: false,
+            detail: "invalid composed strategy metadata schema",
+          };
+        }
+
+        if (
           !Object.hasOwn(metadata, "version") ||
+          metadata.version !== COMPOSED_METADATA_VERSION
+        ) {
+          return {
+            ok: false,
+            detail: "unsupported composed strategy metadata version",
+          };
+        }
+
+        if (
           !Object.hasOwn(metadata, "data") ||
-          metadata.schema !== COMPOSED_METADATA_SCHEMA ||
-          metadata.version !== COMPOSED_METADATA_VERSION ||
           metadata.data === null ||
           typeof metadata.data !== "object"
         ) {
-          return { ok: false };
+          return {
+            ok: false,
+            detail: "composed strategy metadata data must be an object",
+          };
         }
 
         const metadataData = metadata.data as Record<PropertyKey, unknown>;
@@ -60,7 +82,10 @@ export function composeStrategies<
           Object.keys(metadataData).length !== keys.length ||
           !keys.every((key) => Object.hasOwn(metadataData, key))
         ) {
-          return { ok: false };
+          return {
+            ok: false,
+            detail: "composed strategy metadata keys do not match",
+          };
         }
 
         const parsedEntries: Array<[PropertyKey, unknown]> = [];
@@ -69,7 +94,13 @@ export function composeStrategies<
           const result = strategies[key].metadata.parse(metadataData[key]);
 
           if (!result.ok) {
-            return { ok: false };
+            return {
+              ok: false,
+              detail: {
+                strategy: String(key),
+                detail: result.detail,
+              },
+            };
           }
 
           parsedEntries.push([key, result.value]);

--- a/extensions/plugin-stack-persistence/src/composeStrategies.ts
+++ b/extensions/plugin-stack-persistence/src/composeStrategies.ts
@@ -39,7 +39,7 @@ export function composeStrategies<
         if (data === null || typeof data !== "object") {
           return {
             ok: false,
-            detail: "composed strategy metadata must be an object",
+            detail: new Error("composed strategy metadata must be an object"),
           };
         }
 
@@ -51,7 +51,7 @@ export function composeStrategies<
         ) {
           return {
             ok: false,
-            detail: "invalid composed strategy metadata schema",
+            detail: new Error("invalid composed strategy metadata schema"),
           };
         }
 
@@ -61,7 +61,7 @@ export function composeStrategies<
         ) {
           return {
             ok: false,
-            detail: "unsupported composed strategy metadata version",
+            detail: new Error("unsupported composed strategy metadata version"),
           };
         }
 
@@ -72,7 +72,7 @@ export function composeStrategies<
         ) {
           return {
             ok: false,
-            detail: "composed strategy metadata data must be an object",
+            detail: new Error("composed strategy metadata data must be an object"),
           };
         }
 
@@ -84,7 +84,7 @@ export function composeStrategies<
         ) {
           return {
             ok: false,
-            detail: "composed strategy metadata keys do not match",
+            detail: new Error("composed strategy metadata keys do not match"),
           };
         }
 

--- a/extensions/plugin-stack-persistence/src/errors.ts
+++ b/extensions/plugin-stack-persistence/src/errors.ts
@@ -17,3 +17,13 @@ export class StackSnapshotRecordLoadError extends Error {
     this.cause = cause;
   }
 }
+
+export class StackSnapshotMetadataParseError extends Error {
+  detail?: unknown;
+
+  constructor(detail?: unknown) {
+    super("failed to parse stack snapshot metadata");
+    this.name = "StackSnapshotMetadataParseError";
+    this.detail = detail;
+  }
+}

--- a/extensions/plugin-stack-persistence/src/index.ts
+++ b/extensions/plugin-stack-persistence/src/index.ts
@@ -3,6 +3,7 @@ export {
   type StrategiesMetadata,
 } from "./composeStrategies";
 export {
+  StackSnapshotMetadataParseError,
   StackSnapshotRecordLoadError,
   StackSnapshotRecordSaveError,
 } from "./errors";

--- a/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
+++ b/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
@@ -10,8 +10,9 @@ import type { StackSnapshotStrategy } from "./StackSnapshotStrategy";
 export type StackPersistencePluginOptions<Metadata> = {
   storage: StackSnapshotStorage<Metadata>;
   strategy: StackSnapshotStrategy<Metadata>;
-  onMetadataParseError?: (error: StackSnapshotMetadataParseError) => void;
-  onRecordLoadError?: (error: StackSnapshotRecordLoadError) => void;
+  onRecordLoadError?: (
+    error: StackSnapshotRecordLoadError | StackSnapshotMetadataParseError,
+  ) => void;
   onRecordSaveError?: (error: StackSnapshotRecordSaveError) => void;
   onLoadError?: NonNullable<ReturnType<StackflowPlugin>["onLoadError"]>;
 };
@@ -19,7 +20,6 @@ export type StackPersistencePluginOptions<Metadata> = {
 export function stackPersistencePlugin<Metadata>({
   storage,
   strategy,
-  onMetadataParseError,
   onRecordLoadError,
   onRecordSaveError,
   onLoadError,
@@ -66,13 +66,13 @@ export function stackPersistencePlugin<Metadata>({
         try {
           parsedMetadata = strategy.metadata.parse(record.metadata);
         } catch (detail) {
-          onMetadataParseError?.(new StackSnapshotMetadataParseError(detail));
+          onRecordLoadError?.(new StackSnapshotMetadataParseError(detail));
 
           return null;
         }
 
         if (!parsedMetadata.ok) {
-          onMetadataParseError?.(
+          onRecordLoadError?.(
             new StackSnapshotMetadataParseError(parsedMetadata.detail),
           );
 

--- a/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
+++ b/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
@@ -1,5 +1,6 @@
 import type { StackflowActions, StackflowPlugin } from "@stackflow/core";
 import {
+  StackSnapshotMetadataParseError,
   StackSnapshotRecordLoadError,
   StackSnapshotRecordSaveError,
 } from "./errors";
@@ -53,7 +54,9 @@ export function stackPersistencePlugin<Metadata>({
 
           const parsedMetadata = strategy.metadata.parse(record.metadata);
 
-          if (!parsedMetadata.ok) return null;
+          if (!parsedMetadata.ok) {
+            throw new StackSnapshotMetadataParseError(parsedMetadata.detail);
+          }
 
           const parsedRecord = {
             ...record,

--- a/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
+++ b/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
@@ -10,6 +10,7 @@ import type { StackSnapshotStrategy } from "./StackSnapshotStrategy";
 export type StackPersistencePluginOptions<Metadata> = {
   storage: StackSnapshotStorage<Metadata>;
   strategy: StackSnapshotStrategy<Metadata>;
+  onMetadataParseError?: (error: StackSnapshotMetadataParseError) => void;
   onRecordLoadError?: (error: StackSnapshotRecordLoadError) => void;
   onRecordSaveError?: (error: StackSnapshotRecordSaveError) => void;
   onLoadError?: NonNullable<ReturnType<StackflowPlugin>["onLoadError"]>;
@@ -18,6 +19,7 @@ export type StackPersistencePluginOptions<Metadata> = {
 export function stackPersistencePlugin<Metadata>({
   storage,
   strategy,
+  onMetadataParseError,
   onRecordLoadError,
   onRecordSaveError,
   onLoadError,
@@ -47,22 +49,42 @@ export function stackPersistencePlugin<Metadata>({
     return {
       key: "@stackflow/plugin-stack-persistence",
       provideSnapshot({ initialContext }) {
+        let record: ReturnType<typeof storage.load>;
+
         try {
-          const record = storage.load();
+          record = storage.load();
+        } catch (error) {
+          onRecordLoadError?.(new StackSnapshotRecordLoadError(error));
 
-          if (!record) return null;
+          return null;
+        }
 
-          const parsedMetadata = strategy.metadata.parse(record.metadata);
+        if (!record) return null;
 
-          if (!parsedMetadata.ok) {
-            throw new StackSnapshotMetadataParseError(parsedMetadata.detail);
-          }
+        let parsedMetadata: ReturnType<typeof strategy.metadata.parse>;
 
-          const parsedRecord = {
-            ...record,
-            metadata: parsedMetadata.value,
-          };
+        try {
+          parsedMetadata = strategy.metadata.parse(record.metadata);
+        } catch (detail) {
+          onMetadataParseError?.(new StackSnapshotMetadataParseError(detail));
 
+          return null;
+        }
+
+        if (!parsedMetadata.ok) {
+          onMetadataParseError?.(
+            new StackSnapshotMetadataParseError(parsedMetadata.detail),
+          );
+
+          return null;
+        }
+
+        const parsedRecord = {
+          ...record,
+          metadata: parsedMetadata.value,
+        };
+
+        try {
           if (!strategy.shouldReuse({ record: parsedRecord, initialContext })) {
             return null;
           }

--- a/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
+++ b/extensions/plugin-stack-persistence/src/stackPersistencePlugin.ts
@@ -61,15 +61,7 @@ export function stackPersistencePlugin<Metadata>({
 
         if (!record) return null;
 
-        let parsedMetadata: ReturnType<typeof strategy.metadata.parse>;
-
-        try {
-          parsedMetadata = strategy.metadata.parse(record.metadata);
-        } catch (detail) {
-          onRecordLoadError?.(new StackSnapshotMetadataParseError(detail));
-
-          return null;
-        }
+        const parsedMetadata = strategy.metadata.parse(record.metadata);
 
         if (!parsedMetadata.ok) {
           onRecordLoadError?.(
@@ -84,17 +76,11 @@ export function stackPersistencePlugin<Metadata>({
           metadata: parsedMetadata.value,
         };
 
-        try {
-          if (!strategy.shouldReuse({ record: parsedRecord, initialContext })) {
-            return null;
-          }
-
-          return parsedRecord.snapshot;
-        } catch (error) {
-          onRecordLoadError?.(new StackSnapshotRecordLoadError(error));
-
+        if (!strategy.shouldReuse({ record: parsedRecord, initialContext })) {
           return null;
         }
+
+        return parsedRecord.snapshot;
       },
       onLoadError(...args) {
         return onLoadError?.(...args) ?? { policy: "recover" };


### PR DESCRIPTION
## Summary

- Report storage and metadata parse failures through the existing onRecordLoadError callback as distinct error types.
- Add optional detail to failed metadata parse results and preserve nested composed-strategy details.
- Export StackSnapshotMetadataParseError and update the package changeset.