### PR TITLE
fix(core): resume without queued events

### DIFF
--- a/.changeset/fep-2636-resume-without-queued-events.md
+++ b/.changeset/fep-2636-resume-without-queued-events.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/core": patch
+---
+
+Fix `resume()` leaving a Stack paused when no navigation event was queued after `pause()`.

--- a/core/src/activity-utils/makeStackReducer.ts
+++ b/core/src/activity-utils/makeStackReducer.ts
@@ -11,6 +11,18 @@ import { makeActivitiesReducer } from "./makeActivitiesReducer";
 import { makeActivityReducer } from "./makeActivityReducer";
 import { makeReducer } from "./makeReducer";
 
+function getGlobalTransitionState(
+  activities: Stack["activities"],
+): Exclude<Stack["globalTransitionState"], "paused"> {
+  return activities.some(
+    (activity) =>
+      activity.transitionState === "enter-active" ||
+      activity.transitionState === "exit-active",
+  )
+    ? "loading"
+    : "idle";
+}
+
 function withPauseReducer<T extends DomainEvent>(
   reducer: (stack: Stack, event: T) => Stack,
 ) {
@@ -63,18 +75,10 @@ function withActivitiesReducer<T extends DomainEvent>(
       );
     }
 
-    const isLoading = activities.find(
-      (activity) =>
-        activity.transitionState === "enter-active" ||
-        activity.transitionState === "exit-active",
-    );
-
     const globalTransitionState =
       stack.globalTransitionState === "paused"
         ? "paused"
-        : isLoading
-          ? "loading"
-          : "idle";
+        : getGlobalTransitionState(activities);
 
     return reducer({ ...stack, activities, globalTransitionState }, event);
   };
@@ -128,7 +132,7 @@ export function makeStackReducer(context: { now: number; resumedAt?: number }) {
     ),
     Resumed: withActivitiesReducer(
       (stack: Stack, event: ResumedEvent): Stack => {
-        if (stack.globalTransitionState !== "paused" || !stack.pausedEvents) {
+        if (stack.globalTransitionState !== "paused") {
           return { ...stack, events: [...stack.events, event] };
         }
 
@@ -137,10 +141,10 @@ export function makeStackReducer(context: { now: number; resumedAt?: number }) {
           resumedAt: event.eventDate,
         });
 
-        const { pausedEvents, ...rest } = stack;
+        const { pausedEvents = [], ...rest } = stack;
         const resumedStack = pausedEvents.reduce(reducer, {
           ...rest,
-          globalTransitionState: "idle",
+          globalTransitionState: getGlobalTransitionState(rest.activities),
         });
 
         return {

--- a/core/src/activity-utils/makeStackReducer.ts
+++ b/core/src/activity-utils/makeStackReducer.ts
@@ -11,18 +11,6 @@ import { makeActivitiesReducer } from "./makeActivitiesReducer";
 import { makeActivityReducer } from "./makeActivityReducer";
 import { makeReducer } from "./makeReducer";
 
-function getGlobalTransitionState(
-  activities: Stack["activities"],
-): Exclude<Stack["globalTransitionState"], "paused"> {
-  return activities.some(
-    (activity) =>
-      activity.transitionState === "enter-active" ||
-      activity.transitionState === "exit-active",
-  )
-    ? "loading"
-    : "idle";
-}
-
 function withPauseReducer<T extends DomainEvent>(
   reducer: (stack: Stack, event: T) => Stack,
 ) {
@@ -75,10 +63,18 @@ function withActivitiesReducer<T extends DomainEvent>(
       );
     }
 
+    const isLoading = activities.find(
+      (activity) =>
+        activity.transitionState === "enter-active" ||
+        activity.transitionState === "exit-active",
+    );
+
     const globalTransitionState =
       stack.globalTransitionState === "paused"
         ? "paused"
-        : getGlobalTransitionState(activities);
+        : isLoading
+          ? "loading"
+          : "idle";
 
     return reducer({ ...stack, activities, globalTransitionState }, event);
   };
@@ -144,7 +140,13 @@ export function makeStackReducer(context: { now: number; resumedAt?: number }) {
         const { pausedEvents = [], ...rest } = stack;
         const resumedStack = pausedEvents.reduce(reducer, {
           ...rest,
-          globalTransitionState: getGlobalTransitionState(rest.activities),
+          globalTransitionState: rest.activities.some(
+            (activity) =>
+              activity.transitionState === "enter-active" ||
+              activity.transitionState === "exit-active",
+          )
+            ? "loading"
+            : "idle",
         });
 
         return {

--- a/core/src/aggregate.spec.ts
+++ b/core/src/aggregate.spec.ts
@@ -4132,6 +4132,35 @@ test("aggregate - Pause되면 이벤트가 반영되지 않고, globalTransition
   });
 });
 
+test("aggregate - queued event 없이 Resumed 되어도 paused 상태를 해제합니다", () => {
+  const events = [
+    initializedEvent({
+      transitionDuration: 300,
+    }),
+    registeredEvent({
+      activityName: "a",
+    }),
+    makeEvent("Pushed", {
+      activityId: "activity-1",
+      activityName: "a",
+      eventDate: enoughPastTime(),
+      activityParams: {},
+    }),
+    makeEvent("Paused", {
+      eventDate: enoughPastTime(),
+    }),
+    makeEvent("Resumed", {
+      eventDate: enoughPastTime(),
+    }),
+  ];
+
+  const output = aggregate(events, nowTime());
+
+  expect(output.globalTransitionState).toBe("idle");
+  expect(output.pausedEvents).toBeUndefined();
+  expect(output.events).toStrictEqual(events);
+});
+
 test("aggregate - Resumed 되면 해당 시간 이후로 Transition이 정상작동합니다", () => {
   let pushedEvent1: PushedEvent;
   let pushedEvent2: PushedEvent;

--- a/core/src/makeCoreStore.spec.ts
+++ b/core/src/makeCoreStore.spec.ts
@@ -281,3 +281,51 @@ test("makeCoreStore - subscribe에 등록한 이후에 아무 Event가 없는 �
 
   expect(listener1).toHaveBeenCalledTimes(0);
 });
+
+test("makeCoreStore - queued event 없이 resume해도 Stack이 재개됩니다", () => {
+  const onResumed = jest.fn();
+
+  const { actions, pullEvents } = makeCoreStore({
+    initialEvents: [
+      makeEvent("Initialized", {
+        transitionDuration: 150,
+        eventDate: enoughPastTime(),
+      }),
+      makeEvent("ActivityRegistered", {
+        activityName: "hello",
+        eventDate: enoughPastTime(),
+      }),
+      makeEvent("Pushed", {
+        activityId: "a1",
+        activityName: "hello",
+        activityParams: {},
+        eventDate: enoughPastTime(),
+      }),
+    ],
+    plugins: [
+      () => ({
+        key: "test",
+        onResumed,
+      }),
+    ],
+  });
+
+  actions.pause();
+
+  expect(actions.getStack().globalTransitionState).toBe("paused");
+  expect(actions.getStack().pausedEvents).toBeUndefined();
+
+  actions.resume();
+
+  expect(actions.getStack().globalTransitionState).toBe("idle");
+  expect(onResumed).toHaveBeenCalledTimes(1);
+  expect(last(pullEvents())?.name).toBe("Resumed");
+
+  actions.push({
+    activityId: "a2",
+    activityName: "hello",
+    activityParams: {},
+  });
+
+  expect(last(actions.getStack().activities)?.id).toBe("a2");
+});


### PR DESCRIPTION
## Summary

- Resume a paused Stack even when no events were queued after `pause()`.
- Restore `globalTransitionState` to `idle` or `loading` from the current Activity transitions when resuming.
- Add aggregate and core-store regression coverage, including `onResumed` and subsequent navigation.

Linear: [FEP-2636](https://linear.app/daangn/issue/FEP-2636/queued-event-%EC%97%86%EB%8A%94-paused-%EC%A7%81%ED%9B%84-resumed%EA%B0%80-stack%EC%9D%84-paused-%EC%83%81%ED%83%9C%EC%97%90-%EB%82%A8%EA%B9%80)
