### PR TITLE
fix(react): keep loader results out of snapshots (FEP-2613)

### DIFF
--- a/.changeset/fep-2613-loader-result-reference.md
+++ b/.changeset/fep-2613-loader-result-reference.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/react": patch
+---
+
+Keep loader results out of navigation snapshots by storing opaque references in activity context and resolving them within the React loader plugin.

--- a/integrations/react/src/loader/LoaderResultContext.tsx
+++ b/integrations/react/src/loader/LoaderResultContext.tsx
@@ -1,24 +1,6 @@
-import { createContext, type ReactNode, useContext } from "react";
+import { createContext } from "react";
 import type { SyncInspectablePromise } from "../utils/SyncInspectablePromise";
 
-const LoaderResultContext = createContext<
+export const LoaderResultContext = createContext<
   SyncInspectablePromise<unknown> | undefined
 >(undefined);
-
-export function LoaderResultProvider({
-  loaderResultPromise,
-  children,
-}: {
-  loaderResultPromise: SyncInspectablePromise<unknown> | undefined;
-  children: ReactNode;
-}) {
-  return (
-    <LoaderResultContext.Provider value={loaderResultPromise}>
-      {children}
-    </LoaderResultContext.Provider>
-  );
-}
-
-export function useLoaderResultPromise() {
-  return useContext(LoaderResultContext);
-}

--- a/integrations/react/src/loader/LoaderResultContext.tsx
+++ b/integrations/react/src/loader/LoaderResultContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, type ReactNode, useContext } from "react";
+import type { SyncInspectablePromise } from "../utils/SyncInspectablePromise";
+
+const LoaderResultContext = createContext<
+  SyncInspectablePromise<unknown> | undefined
+>(undefined);
+
+export function LoaderResultProvider({
+  loaderResultPromise,
+  children,
+}: {
+  loaderResultPromise: SyncInspectablePromise<unknown> | undefined;
+  children: ReactNode;
+}) {
+  return (
+    <LoaderResultContext.Provider value={loaderResultPromise}>
+      {children}
+    </LoaderResultContext.Provider>
+  );
+}
+
+export function useLoaderResultPromise() {
+  return useContext(LoaderResultContext);
+}

--- a/integrations/react/src/loader/LoaderResultStore.ts
+++ b/integrations/react/src/loader/LoaderResultStore.ts
@@ -1,0 +1,94 @@
+import {
+  defer,
+  type SyncInspectablePromise,
+} from "../utils/SyncInspectablePromise";
+
+const LOADER_RESULT_ID_KEY = "@stackflow/react/loaderResultId";
+
+export type LoaderResultId = string;
+
+type LoaderResultEntry = {
+  promise: SyncInspectablePromise<unknown>;
+  start?: (load: () => unknown) => boolean;
+};
+
+let nextLoaderResultId = 0;
+
+export class LoaderResultStore {
+  private readonly entries = new Map<LoaderResultId, LoaderResultEntry>();
+
+  add(promise: SyncInspectablePromise<unknown>): LoaderResultId {
+    const loaderResultId = makeLoaderResultId();
+    this.entries.set(loaderResultId, { promise });
+    return loaderResultId;
+  }
+
+  addDeferred(): LoaderResultId {
+    const loaderData = defer<unknown>();
+    let started = false;
+    const loaderResultId = makeLoaderResultId();
+
+    this.entries.set(loaderResultId, {
+      promise: loaderData.promise,
+      start(load) {
+        if (started) {
+          return false;
+        }
+
+        started = true;
+
+        try {
+          loaderData.resolve(load());
+        } catch (error) {
+          loaderData.reject(error);
+        }
+
+        return true;
+      },
+    });
+
+    return loaderResultId;
+  }
+
+  get(loaderResultId: LoaderResultId | undefined) {
+    return loaderResultId
+      ? this.entries.get(loaderResultId)?.promise
+      : undefined;
+  }
+
+  start(loaderResultId: LoaderResultId, load: () => unknown) {
+    const entry = this.entries.get(loaderResultId);
+
+    if (!entry?.start || !entry.start(load)) {
+      return undefined;
+    }
+
+    return entry.promise;
+  }
+
+  getId(activityContext: unknown): LoaderResultId | undefined {
+    if (typeof activityContext !== "object" || activityContext === null) {
+      return undefined;
+    }
+
+    const loaderResultId = (activityContext as Record<string, unknown>)[
+      LOADER_RESULT_ID_KEY
+    ];
+
+    return typeof loaderResultId === "string" ? loaderResultId : undefined;
+  }
+
+  withId(activityContext: unknown, loaderResultId: LoaderResultId) {
+    return {
+      ...(typeof activityContext === "object" && activityContext !== null
+        ? activityContext
+        : {}),
+      [LOADER_RESULT_ID_KEY]: loaderResultId,
+    };
+  }
+}
+
+function makeLoaderResultId(): LoaderResultId {
+  nextLoaderResultId += 1;
+  return nextLoaderResultId.toString();
+}

--- a/integrations/react/src/loader/loaderPlugin.tsx
+++ b/integrations/react/src/loader/loaderPlugin.tsx
@@ -11,55 +11,12 @@ import {
 } from "../StructuredActivityComponentType";
 import type { StackflowInput } from "../stackflow";
 import { LoaderResultContext } from "./LoaderResultContext";
+import { LoaderResultStore, type LoaderResultId } from "./LoaderResultStore";
 import {
-  defer,
   inspect,
   PromiseStatus,
   resolve,
-  type SyncInspectablePromise,
 } from "../utils/SyncInspectablePromise";
-
-const LOADER_RESULT_ID_KEY = "@stackflow/react/loaderResultId";
-
-type LoaderResultId = string;
-
-type LoaderResultEntry = {
-  promise: SyncInspectablePromise<unknown>;
-  start?: (load: () => unknown) => boolean;
-};
-
-let nextLoaderResultId = 0;
-
-function makeLoaderResultId(): LoaderResultId {
-  nextLoaderResultId += 1;
-  return nextLoaderResultId.toString();
-}
-
-function getLoaderResultId(
-  activityContext: unknown,
-): LoaderResultId | undefined {
-  if (typeof activityContext !== "object" || activityContext === null) {
-    return undefined;
-  }
-
-  const loaderResultId = (activityContext as Record<string, unknown>)[
-    LOADER_RESULT_ID_KEY
-  ];
-
-  return typeof loaderResultId === "string" ? loaderResultId : undefined;
-}
-
-function withLoaderResultId(
-  activityContext: unknown,
-  loaderResultId: LoaderResultId,
-) {
-  return {
-    ...(typeof activityContext === "object" && activityContext !== null
-      ? activityContext
-      : {}),
-    [LOADER_RESULT_ID_KEY]: loaderResultId,
-  };
-}
 
 export function loaderPlugin<
   T extends ActivityDefinition<RegisteredActivityName>,
@@ -71,40 +28,7 @@ export function loaderPlugin<
   loadData: (activityName: string, activityParams: {}) => unknown,
 ): StackflowReactPlugin {
   return () => {
-    const loaderResults = new Map<LoaderResultId, LoaderResultEntry>();
-
-    const addLoaderResult = (promise: SyncInspectablePromise<unknown>) => {
-      const loaderResultId = makeLoaderResultId();
-      loaderResults.set(loaderResultId, { promise });
-      return loaderResultId;
-    };
-
-    const addDeferredLoaderResult = () => {
-      const loaderData = defer<unknown>();
-      let started = false;
-      const loaderResultId = makeLoaderResultId();
-
-      loaderResults.set(loaderResultId, {
-        promise: loaderData.promise,
-        start(load) {
-          if (started) {
-            return false;
-          }
-
-          started = true;
-
-          try {
-            loaderData.resolve(load());
-          } catch (error) {
-            loaderData.reject(error);
-          }
-
-          return true;
-        },
-      });
-
-      return loaderResultId;
-    };
+    const loaderResultStore = new LoaderResultStore();
 
     const resolveDeferredLoaderData = ({
       activityName,
@@ -118,26 +42,24 @@ export function loaderPlugin<
       const matchActivity = input.config.activities.find(
         (candidate) => candidate.name === activityName,
       );
-      const loaderResult = loaderResultId
-        ? loaderResults.get(loaderResultId)
-        : undefined;
-
-      if (!matchActivity?.loader || !loaderResult?.start) {
+      if (!matchActivity?.loader || !loaderResultId) {
         return;
       }
 
-      if (!loaderResult.start(() => loadData(activityName, activityParams))) {
-        return;
-      }
-
-      Promise.allSettled([loaderResult.promise]).then(
-        ([loaderDataPromiseResult]) => {
-          printLoaderDataPromiseError({
-            promiseResult: loaderDataPromiseResult,
-            activityName: matchActivity.name,
-          });
-        },
+      const loaderData = loaderResultStore.start(loaderResultId, () =>
+        loadData(activityName, activityParams),
       );
+
+      if (!loaderData) {
+        return;
+      }
+
+      Promise.allSettled([loaderData]).then(([loaderDataPromiseResult]) => {
+        printLoaderDataPromiseError({
+          promiseResult: loaderDataPromiseResult,
+          activityName: matchActivity.name,
+        });
+      });
     };
 
     const resolveRestoredStackLoaderData = (stack: Stack) => {
@@ -147,7 +69,7 @@ export function loaderPlugin<
           resolveDeferredLoaderData({
             activityName: activity.name,
             activityParams: activity.params,
-            loaderResultId: getLoaderResultId(activity.context),
+            loaderResultId: loaderResultStore.getId(activity.context),
           });
         });
     };
@@ -163,7 +85,7 @@ export function loaderPlugin<
         resolveDeferredLoaderData({
           activityName: event.activityName,
           activityParams: event.activityParams,
-          loaderResultId: getLoaderResultId(event.activityContext),
+          loaderResultId: loaderResultStore.getId(event.activityContext),
         });
       });
     };
@@ -189,11 +111,11 @@ export function loaderPlugin<
               return event;
             }
 
-            const loaderResultId = addDeferredLoaderResult();
+            const loaderResultId = loaderResultStore.addDeferred();
 
             return {
               ...event,
-              activityContext: withLoaderResultId(
+              activityContext: loaderResultStore.withId(
                 event.activityContext,
                 loaderResultId,
               ),
@@ -219,13 +141,13 @@ export function loaderPlugin<
           }
 
           if (initialContext.initialLoaderData) {
-            const loaderResultId = addLoaderResult(
+            const loaderResultId = loaderResultStore.add(
               resolve(initialContext.initialLoaderData),
             );
 
             return {
               ...event,
-              activityContext: withLoaderResultId(
+              activityContext: loaderResultStore.withId(
                 event.activityContext,
                 loaderResultId,
               ),
@@ -233,7 +155,7 @@ export function loaderPlugin<
           }
 
           const loaderData = resolve(loadData(activityName, activityParams));
-          const loaderResultId = addLoaderResult(loaderData);
+          const loaderResultId = loaderResultStore.add(loaderData);
 
           Promise.allSettled([loaderData]).then(([loaderDataPromiseResult]) => {
             printLoaderDataPromiseError({
@@ -244,7 +166,7 @@ export function loaderPlugin<
 
           return {
             ...event,
-            activityContext: withLoaderResultId(
+            activityContext: loaderResultStore.withId(
               event.activityContext,
               loaderResultId,
             ),
@@ -260,17 +182,20 @@ export function loaderPlugin<
         resolveRestoredStackLoaderData(stack);
         resolvePausedEventLoaderData(stack.pausedEvents);
       },
-      onBeforePush: createBeforeRouteHandler(input, loadData, addLoaderResult),
+      onBeforePush: createBeforeRouteHandler(
+        input,
+        loadData,
+        loaderResultStore,
+      ),
       onBeforeReplace: createBeforeRouteHandler(
         input,
         loadData,
-        addLoaderResult,
+        loaderResultStore,
       ),
       wrapActivity({ activity }) {
-        const loaderResultId = getLoaderResultId(activity.context);
-        const loaderResultPromise = loaderResultId
-          ? loaderResults.get(loaderResultId)?.promise
-          : undefined;
+        const loaderResultPromise = loaderResultStore.get(
+          loaderResultStore.getId(activity.context),
+        );
 
         return (
           <LoaderResultContext.Provider value={loaderResultPromise}>
@@ -295,7 +220,7 @@ function createBeforeRouteHandler<
 >(
   input: StackflowInput<T, R>,
   loadData: (activityName: string, activityParams: {}) => unknown,
-  addLoaderResult: (promise: SyncInspectablePromise<unknown>) => LoaderResultId,
+  loaderResultStore: LoaderResultStore,
 ): OnBeforeRoute {
   return ({ actionParams, actions }) => {
     if (actions.isPrevented()) {
@@ -356,11 +281,14 @@ function createBeforeRouteHandler<
       return;
     }
 
-    const loaderResultId = addLoaderResult(loaderData);
+    const loaderResultId = loaderResultStore.add(loaderData);
 
     overrideActionParams({
       ...actionParams,
-      activityContext: withLoaderResultId(activityContext, loaderResultId),
+      activityContext: loaderResultStore.withId(
+        activityContext,
+        loaderResultId,
+      ),
     });
   };
 }

--- a/integrations/react/src/loader/loaderPlugin.tsx
+++ b/integrations/react/src/loader/loaderPlugin.tsx
@@ -2,7 +2,7 @@ import type {
   ActivityDefinition,
   RegisteredActivityName,
 } from "@stackflow/config";
-import type { Stack } from "@stackflow/core";
+import { id, type Stack } from "@stackflow/core";
 import type { ActivityComponentType } from "../BaseActivityComponentType";
 import type { StackflowReactPlugin } from "../StackflowReactPlugin";
 import {
@@ -10,14 +10,49 @@ import {
   isStructuredActivityComponent,
 } from "../StructuredActivityComponentType";
 import type { StackflowInput } from "../stackflow";
+import { LoaderResultProvider } from "./LoaderResultContext";
 import {
   defer,
   inspect,
   PromiseStatus,
   resolve,
-  type SyncInspectableDeferred,
   type SyncInspectablePromise,
 } from "../utils/SyncInspectablePromise";
+
+const LOADER_RESULT_ID_KEY = "@stackflow/react/loaderResultId";
+
+type LoaderResultId = string;
+
+type LoaderResultEntry = {
+  promise: SyncInspectablePromise<unknown>;
+  start?: (load: () => unknown) => boolean;
+};
+
+function getLoaderResultId(
+  activityContext: unknown,
+): LoaderResultId | undefined {
+  if (typeof activityContext !== "object" || activityContext === null) {
+    return undefined;
+  }
+
+  const loaderResultId = (activityContext as Record<string, unknown>)[
+    LOADER_RESULT_ID_KEY
+  ];
+
+  return typeof loaderResultId === "string" ? loaderResultId : undefined;
+}
+
+function withLoaderResultId(
+  activityContext: unknown,
+  loaderResultId: LoaderResultId,
+) {
+  return {
+    ...(typeof activityContext === "object" && activityContext !== null
+      ? activityContext
+      : {}),
+    [LOADER_RESULT_ID_KEY]: loaderResultId,
+  };
+}
 
 export function loaderPlugin<
   T extends ActivityDefinition<RegisteredActivityName>,
@@ -29,45 +64,73 @@ export function loaderPlugin<
   loadData: (activityName: string, activityParams: {}) => unknown,
 ): StackflowReactPlugin {
   return () => {
-    const loadPathDeferreds = new WeakMap<
-      SyncInspectablePromise<unknown>,
-      SyncInspectableDeferred<unknown>
-    >();
+    const loaderResults = new Map<LoaderResultId, LoaderResultEntry>();
+
+    const addLoaderResult = (promise: SyncInspectablePromise<unknown>) => {
+      const loaderResultId = id();
+      loaderResults.set(loaderResultId, { promise });
+      return loaderResultId;
+    };
+
+    const addDeferredLoaderResult = () => {
+      const loaderData = defer<unknown>();
+      let started = false;
+      const loaderResultId = id();
+
+      loaderResults.set(loaderResultId, {
+        promise: loaderData.promise,
+        start(load) {
+          if (started) {
+            return false;
+          }
+
+          started = true;
+
+          try {
+            loaderData.resolve(load());
+          } catch (error) {
+            loaderData.reject(error);
+          }
+
+          return true;
+        },
+      });
+
+      return loaderResultId;
+    };
 
     const resolveDeferredLoaderData = ({
       activityName,
       activityParams,
-      loaderData,
+      loaderResultId,
     }: {
       activityName: string;
       activityParams: {};
-      loaderData: SyncInspectablePromise<unknown> | undefined;
+      loaderResultId: LoaderResultId | undefined;
     }) => {
       const matchActivity = input.config.activities.find(
         (candidate) => candidate.name === activityName,
       );
-      const deferred = loaderData
-        ? loadPathDeferreds.get(loaderData)
+      const loaderResult = loaderResultId
+        ? loaderResults.get(loaderResultId)
         : undefined;
 
-      if (!matchActivity?.loader || !loaderData || !deferred) {
+      if (!matchActivity?.loader || !loaderResult?.start) {
         return;
       }
 
-      loadPathDeferreds.delete(loaderData);
-
-      Promise.allSettled([loaderData]).then(([loaderDataPromiseResult]) => {
-        printLoaderDataPromiseError({
-          promiseResult: loaderDataPromiseResult,
-          activityName: matchActivity.name,
-        });
-      });
-
-      try {
-        deferred.resolve(loadData(activityName, activityParams));
-      } catch (error) {
-        deferred.reject(error);
+      if (!loaderResult.start(() => loadData(activityName, activityParams))) {
+        return;
       }
+
+      Promise.allSettled([loaderResult.promise]).then(
+        ([loaderDataPromiseResult]) => {
+          printLoaderDataPromiseError({
+            promiseResult: loaderDataPromiseResult,
+            activityName: matchActivity.name,
+          });
+        },
+      );
     };
 
     const resolveRestoredStackLoaderData = (stack: Stack) => {
@@ -77,7 +140,7 @@ export function loaderPlugin<
           resolveDeferredLoaderData({
             activityName: activity.name,
             activityParams: activity.params,
-            loaderData: (activity.context as any)?.loaderData,
+            loaderResultId: getLoaderResultId(activity.context),
           });
         });
     };
@@ -93,7 +156,7 @@ export function loaderPlugin<
         resolveDeferredLoaderData({
           activityName: event.activityName,
           activityParams: event.activityParams,
-          loaderData: (event.activityContext as any)?.loaderData,
+          loaderResultId: getLoaderResultId(event.activityContext),
         });
       });
     };
@@ -119,15 +182,14 @@ export function loaderPlugin<
               return event;
             }
 
-            const loaderData = defer<unknown>();
-            loadPathDeferreds.set(loaderData.promise, loaderData);
+            const loaderResultId = addDeferredLoaderResult();
 
             return {
               ...event,
-              activityContext: {
-                ...event.activityContext,
-                loaderData: loaderData.promise,
-              },
+              activityContext: withLoaderResultId(
+                event.activityContext,
+                loaderResultId,
+              ),
             };
           });
         }
@@ -135,16 +197,6 @@ export function loaderPlugin<
         return initialEvents.map((event) => {
           if (event.name !== "Pushed" && event.name !== "Replaced") {
             return event;
-          }
-
-          if (initialContext.initialLoaderData) {
-            return {
-              ...event,
-              activityContext: {
-                ...event.activityContext,
-                loaderData: resolve(initialContext.initialLoaderData),
-              },
-            };
           }
 
           const { activityName, activityParams } = event;
@@ -159,7 +211,22 @@ export function loaderPlugin<
             return event;
           }
 
+          if (initialContext.initialLoaderData) {
+            const loaderResultId = addLoaderResult(
+              resolve(initialContext.initialLoaderData),
+            );
+
+            return {
+              ...event,
+              activityContext: withLoaderResultId(
+                event.activityContext,
+                loaderResultId,
+              ),
+            };
+          }
+
           const loaderData = resolve(loadData(activityName, activityParams));
+          const loaderResultId = addLoaderResult(loaderData);
 
           Promise.allSettled([loaderData]).then(([loaderDataPromiseResult]) => {
             printLoaderDataPromiseError({
@@ -170,10 +237,10 @@ export function loaderPlugin<
 
           return {
             ...event,
-            activityContext: {
-              ...event.activityContext,
-              loaderData,
-            },
+            activityContext: withLoaderResultId(
+              event.activityContext,
+              loaderResultId,
+            ),
           };
         });
       },
@@ -186,8 +253,24 @@ export function loaderPlugin<
         resolveRestoredStackLoaderData(stack);
         resolvePausedEventLoaderData(stack.pausedEvents);
       },
-      onBeforePush: createBeforeRouteHandler(input, loadData),
-      onBeforeReplace: createBeforeRouteHandler(input, loadData),
+      onBeforePush: createBeforeRouteHandler(input, loadData, addLoaderResult),
+      onBeforeReplace: createBeforeRouteHandler(
+        input,
+        loadData,
+        addLoaderResult,
+      ),
+      wrapActivity({ activity }) {
+        const loaderResultId = getLoaderResultId(activity.context);
+        const loaderResultPromise = loaderResultId
+          ? loaderResults.get(loaderResultId)?.promise
+          : undefined;
+
+        return (
+          <LoaderResultProvider loaderResultPromise={loaderResultPromise}>
+            {activity.render()}
+          </LoaderResultProvider>
+        );
+      },
     };
   };
 }
@@ -205,6 +288,7 @@ function createBeforeRouteHandler<
 >(
   input: StackflowInput<T, R>,
   loadData: (activityName: string, activityParams: {}) => unknown,
+  addLoaderResult: (promise: SyncInspectablePromise<unknown>) => LoaderResultId,
 ): OnBeforeRoute {
   return ({ actionParams, actions }) => {
     if (actions.isPrevented()) {
@@ -261,12 +345,15 @@ function createBeforeRouteHandler<
         });
     }
 
+    if (!loaderData) {
+      return;
+    }
+
+    const loaderResultId = addLoaderResult(loaderData);
+
     overrideActionParams({
       ...actionParams,
-      activityContext: {
-        ...activityContext,
-        loaderData,
-      },
+      activityContext: withLoaderResultId(activityContext, loaderResultId),
     });
   };
 }

--- a/integrations/react/src/loader/loaderPlugin.tsx
+++ b/integrations/react/src/loader/loaderPlugin.tsx
@@ -2,7 +2,7 @@ import type {
   ActivityDefinition,
   RegisteredActivityName,
 } from "@stackflow/config";
-import { id, type Stack } from "@stackflow/core";
+import type { Stack } from "@stackflow/core";
 import type { ActivityComponentType } from "../BaseActivityComponentType";
 import type { StackflowReactPlugin } from "../StackflowReactPlugin";
 import {
@@ -10,7 +10,7 @@ import {
   isStructuredActivityComponent,
 } from "../StructuredActivityComponentType";
 import type { StackflowInput } from "../stackflow";
-import { LoaderResultProvider } from "./LoaderResultContext";
+import { LoaderResultContext } from "./LoaderResultContext";
 import {
   defer,
   inspect,
@@ -27,6 +27,13 @@ type LoaderResultEntry = {
   promise: SyncInspectablePromise<unknown>;
   start?: (load: () => unknown) => boolean;
 };
+
+let nextLoaderResultId = 0;
+
+function makeLoaderResultId(): LoaderResultId {
+  nextLoaderResultId += 1;
+  return nextLoaderResultId.toString();
+}
 
 function getLoaderResultId(
   activityContext: unknown,
@@ -67,7 +74,7 @@ export function loaderPlugin<
     const loaderResults = new Map<LoaderResultId, LoaderResultEntry>();
 
     const addLoaderResult = (promise: SyncInspectablePromise<unknown>) => {
-      const loaderResultId = id();
+      const loaderResultId = makeLoaderResultId();
       loaderResults.set(loaderResultId, { promise });
       return loaderResultId;
     };
@@ -75,7 +82,7 @@ export function loaderPlugin<
     const addDeferredLoaderResult = () => {
       const loaderData = defer<unknown>();
       let started = false;
-      const loaderResultId = id();
+      const loaderResultId = makeLoaderResultId();
 
       loaderResults.set(loaderResultId, {
         promise: loaderData.promise,
@@ -266,9 +273,9 @@ export function loaderPlugin<
           : undefined;
 
         return (
-          <LoaderResultProvider loaderResultPromise={loaderResultPromise}>
+          <LoaderResultContext.Provider value={loaderResultPromise}>
             {activity.render()}
-          </LoaderResultProvider>
+          </LoaderResultContext.Provider>
         );
       },
     };

--- a/integrations/react/src/loader/useLoaderData.ts
+++ b/integrations/react/src/loader/useLoaderData.ts
@@ -1,12 +1,13 @@
 import type { ActivityLoaderArgs } from "@stackflow/config";
+import { useContext } from "react";
 import { resolve } from "../utils/SyncInspectablePromise";
 import { useThenable } from "../utils/useThenable";
-import { useLoaderResultPromise } from "./LoaderResultContext";
+import { LoaderResultContext } from "./LoaderResultContext";
 
 export function useLoaderData<
   T extends (args: ActivityLoaderArgs<any>) => any,
 >(): Awaited<ReturnType<T>> {
-  return useThenable(resolve(useLoaderResultPromise())) as Awaited<
+  return useThenable(resolve(useContext(LoaderResultContext))) as Awaited<
     ReturnType<T>
   >;
 }

--- a/integrations/react/src/loader/useLoaderData.ts
+++ b/integrations/react/src/loader/useLoaderData.ts
@@ -1,10 +1,12 @@
 import type { ActivityLoaderArgs } from "@stackflow/config";
 import { resolve } from "../utils/SyncInspectablePromise";
 import { useThenable } from "../utils/useThenable";
-import { useActivity } from "../activity/useActivity";
+import { useLoaderResultPromise } from "./LoaderResultContext";
 
 export function useLoaderData<
   T extends (args: ActivityLoaderArgs<any>) => any,
 >(): Awaited<ReturnType<T>> {
-  return useThenable(resolve((useActivity().context as any)?.loaderData));
+  return useThenable(resolve(useLoaderResultPromise())) as Awaited<
+    ReturnType<T>
+  >;
 }


### PR DESCRIPTION
- Store loader promises in the plugin instance and write an opaque result ID to activity context.
- Recreate deferred loader results with fresh IDs when loading snapshots, including paused navigation events.
- Provide loader promises through an internal React Context so useLoaderData no longer reads activity context directly.