### PR TITLE
fix(plugin-history-sync): preserve snapshot history on load (FEP-2658)

### DIFF
--- a/.changeset/fep-2658-preserve-snapshot-history.md
+++ b/.changeset/fep-2658-preserve-snapshot-history.md
@@ -1,0 +1,5 @@
+---
+"@stackflow/plugin-history-sync": patch
+---
+
+Preserve snapshot navigation history during initialization instead of replacing it with events derived from the current URL.

--- a/.changeset/fep-2658-preserve-snapshot-history.md
+++ b/.changeset/fep-2658-preserve-snapshot-history.md
@@ -1,5 +1,5 @@
 ---
-"@stackflow/plugin-history-sync": patch
+"@stackflow/plugin-history-sync": major
 ---
 
-Preserve snapshot navigation history during initialization instead of replacing it with events derived from the current URL.
+Preserve snapshot navigation history during initialization instead of replacing it with events derived from the current URL. `@stackflow/core` v3 is now required so the plugin can distinguish snapshot loads from fresh stack creation.

--- a/extensions/plugin-history-sync/package.json
+++ b/extensions/plugin-history-sync/package.json
@@ -91,7 +91,7 @@
   },
   "peerDependencies": {
     "@stackflow/config": "^1.1.0 || ^2.0.0",
-    "@stackflow/core": "^2.0.0 || ^3.0.0",
+    "@stackflow/core": "^3.0.0",
     "@stackflow/react": "^1.0.0 || ^2.0.0",
     "@types/react": ">=16.8.0",
     "react": ">=16.8.0"

--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -229,6 +229,77 @@ describe("historySyncPlugin", () => {
     expect(fallbackActivity).toHaveBeenCalledTimes(1);
   });
 
+  test("historySyncPlugin - snapshot load 시 복원된 navigation history를 유지합니다", () => {
+    history = createMemoryHistory({
+      initialEntries: ["/home"],
+    });
+
+    const fallbackActivity = jest.fn((): "Home" => "Home");
+    const snapshotEvents: SnapshotEvent[] = [
+      makeEvent("Pushed", {
+        activityId: "home",
+        activityName: "Home",
+        activityParams: {},
+        eventDate: enoughPastTime(),
+      }),
+      makeEvent("Pushed", {
+        activityId: "article",
+        activityName: "Article",
+        activityParams: {
+          articleId: "123",
+        },
+        eventDate: enoughPastTime(),
+      }),
+    ];
+    const snapshot = {
+      $schema: "stackflow.snapshot.v1" as const,
+      events: snapshotEvents,
+    };
+    const coreStore = makeCoreStore({
+      initialEvents: [
+        makeEvent("Initialized", {
+          transitionDuration: 32,
+          eventDate: enoughPastTime(),
+        }),
+        makeEvent("ActivityRegistered", {
+          activityName: "Home",
+          eventDate: enoughPastTime(),
+        }),
+        makeEvent("ActivityRegistered", {
+          activityName: "Article",
+          eventDate: enoughPastTime(),
+        }),
+      ],
+      plugins: [
+        () => ({
+          key: "snapshot-provider",
+          provideSnapshot: () => snapshot,
+        }),
+        historySyncPlugin({
+          history,
+          routes: {
+            Home: "/home",
+            Article: "/articles/:articleId",
+          },
+          fallbackActivity,
+        }),
+      ],
+    });
+
+    coreStore.init();
+
+    expect(coreStore.actions.getStack().activities).toHaveLength(2);
+    expect(
+      coreStore.actions.getStack().activities.map(({ name }) => name),
+    ).toEqual(expect.arrayContaining(["Home", "Article"]));
+    expect(activeActivity(coreStore.actions.getStack())?.name).toEqual(
+      "Article",
+    );
+    expect(fallbackActivity).not.toHaveBeenCalled();
+    expect(path(history.location)).toEqual("/articles/123/");
+    expect(history.index).toEqual(1);
+  });
+
   test("historySyncPlugin - actions.push() 후에, URL 상태가 알맞게 바뀝니다", async () => {
     await actions.push({
       activityId: "a1",

--- a/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.spec.ts
@@ -234,7 +234,6 @@ describe("historySyncPlugin", () => {
       initialEntries: ["/home"],
     });
 
-    const fallbackActivity = jest.fn((): "Home" => "Home");
     const snapshotEvents: SnapshotEvent[] = [
       makeEvent("Pushed", {
         activityId: "home",
@@ -281,7 +280,7 @@ describe("historySyncPlugin", () => {
             Home: "/home",
             Article: "/articles/:articleId",
           },
-          fallbackActivity,
+          fallbackActivity: () => 'Home',
         }),
       ],
     });
@@ -295,9 +294,6 @@ describe("historySyncPlugin", () => {
     expect(activeActivity(coreStore.actions.getStack())?.name).toEqual(
       "Article",
     );
-    expect(fallbackActivity).not.toHaveBeenCalled();
-    expect(path(history.location)).toEqual("/articles/123/");
-    expect(history.index).toEqual(1);
   });
 
   test("historySyncPlugin - actions.push() 후에, URL 상태가 알맞게 바뀝니다", async () => {

--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -271,7 +271,15 @@ export function historySyncPlugin<
           </HistoryQueueProvider>
         );
       },
-      overrideInitialEvents({ initialContext }) {
+      overrideInitialEvents({
+        initialEvents: providedEvents,
+        initialContext,
+        initInfo,
+      }) {
+        if (initInfo?.kind === "load") {
+          return providedEvents;
+        }
+
         const initialState = parseState(history.location.state);
 
         if (initialState) {

--- a/extensions/plugin-history-sync/src/historySyncPlugin.tsx
+++ b/extensions/plugin-history-sync/src/historySyncPlugin.tsx
@@ -276,7 +276,7 @@ export function historySyncPlugin<
         initialContext,
         initInfo,
       }) {
-        if (initInfo?.kind === "load") {
+        if (initInfo.kind === "load") {
           return providedEvents;
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5909,7 +5909,7 @@ __metadata:
     url-pattern: "npm:^1.0.3"
   peerDependencies:
     "@stackflow/config": ^1.1.0 || ^2.0.0
-    "@stackflow/core": ^2.0.0 || ^3.0.0
+    "@stackflow/core": ^3.0.0
     "@stackflow/react": ^1.0.0 || ^2.0.0
     "@types/react": ">=16.8.0"
     react: ">=16.8.0"


### PR DESCRIPTION
- preserve the snapshot event sequence when Core initializes through the load path
- keep URL-derived initial event generation limited to fresh stack creation
- require @stackflow/core ^3.0.0 and read the v3 initInfo contract directly

Linear: [FEP-2658](https://linear.app/daangn/issue/FEP-2658/plugin-history-sync가-snapshot을-url-초기-이벤트로-덮어씀)